### PR TITLE
fix(ci): add contents:write to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "loctree-v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Fixes 403 on GitHub Release creation. Org disables default write permissions.