### PR TITLE
fix(ci): switch notarization to API key auth with retry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,9 +225,9 @@ jobs:
       - name: Package macOS ARM64 artifact
         env:
           MACOS_DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: |
           mkdir -p dist/darwin-aarch64
           cp target/aarch64-apple-darwin/release/loctree dist/darwin-aarch64/loctree

--- a/distribution/macos/sign-and-notarize.sh
+++ b/distribution/macos/sign-and-notarize.sh
@@ -10,15 +10,13 @@ DIST_DIR="$1"
 OUTPUT_ZIP="$2"
 
 : "${MACOS_DEVELOPER_ID_APPLICATION:?Set MACOS_DEVELOPER_ID_APPLICATION}"
-: "${APPLE_ID:?Set APPLE_ID}"
-: "${APPLE_TEAM_ID:?Set APPLE_TEAM_ID}"
-: "${APPLE_APP_SPECIFIC_PASSWORD:?Set APPLE_APP_SPECIFIC_PASSWORD}"
 
 if [[ ! -d "$DIST_DIR" ]]; then
   echo "Missing dist dir: $DIST_DIR"
   exit 1
 fi
 
+# --- Codesign ---
 for bin in loctree loct; do
   target="$DIST_DIR/$bin"
   if [[ -f "$target" ]]; then
@@ -29,11 +27,32 @@ done
 rm -f "$OUTPUT_ZIP"
 ditto -c -k --keepParent "$DIST_DIR" "$OUTPUT_ZIP"
 
-xcrun notarytool submit \
-  "$OUTPUT_ZIP" \
-  --apple-id "$APPLE_ID" \
-  --team-id "$APPLE_TEAM_ID" \
-  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
-  --wait
+# --- Notarization (API key auth, 3 retries, 15m timeout) ---
 
-echo "Notarized archive ready: $OUTPUT_ZIP"
+# Resolve auth: prefer API key, fallback to app-specific password
+NOTARY_AUTH=()
+if [[ -n "${APPLE_API_KEY_BASE64:-}" && -n "${APPLE_API_KEY_ID:-}" && -n "${APPLE_API_ISSUER_ID:-}" ]]; then
+  KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+  echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+  NOTARY_AUTH=(--key "$KEY_PATH" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
+  echo "Using API key auth (key-id: $APPLE_API_KEY_ID)"
+elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
+  NOTARY_AUTH=(--apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD")
+  echo "Using app-specific password auth"
+else
+  echo "ERROR: No notarization credentials. Set APPLE_API_KEY_* or APPLE_ID+APPLE_APP_SPECIFIC_PASSWORD"
+  exit 1
+fi
+
+for attempt in 1 2 3; do
+  echo "Notarization attempt $attempt/3..."
+  if xcrun notarytool submit "$OUTPUT_ZIP" "${NOTARY_AUTH[@]}" --wait --timeout 15m; then
+    echo "Notarized archive ready: $OUTPUT_ZIP"
+    exit 0
+  fi
+  echo "Attempt $attempt failed, retrying in 10s..."
+  sleep 10
+done
+
+echo "Notarization failed after 3 attempts"
+exit 1


### PR DESCRIPTION
API key auth + 3 retries + 15m timeout. Fixes connectTimeout on Apple notary.