### PR TITLE
chore(deprivatize): scrub residual private fingerprints for public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,9 +246,9 @@ $ loct find recording_finalize_session transcription_finalize_stream session_not
 | Repo | Indexed Params |
 |------|----------------|
 | mlx-omni-server | 225 |
-| lbrx-services | 899 |
+| example-service | 899 |
 | loctree-suite | 862 |
-| vista | 2362 |
+| example-app | 2362 |
 
 ## [0.8.3] - 2026-01-05
 
@@ -732,7 +732,7 @@ This release dramatically reduces false positives in dead export detection acros
 - **Parser Debug Logging**: Added error logging when OXC parser encounters issues (visible with `--verbose`).
 
 ### Changed
-- **Vista Project Results**: Improved detection accuracy:
+- **Sample Project Results**: Improved detection accuracy:
   - Frontend commands: 170 → 254 (+49%)
   - Missing handlers: 18 → 5 (72% reduction in false positives)
   - Unused handlers: 137 → 57 (58% reduction in false positives)
@@ -1033,7 +1033,7 @@ This release dramatically reduces false positives in dead export detection acros
 - `--ignore-symbols-preset <name>` (currently `common` → `main,run,setup,test_*`) and support for `foo*` prefixes in `--ignore-symbols`.
 
 ### Changed
-- Help/README/Monika guide updated with new flags; duplicate analysis now considers prefix patterns.
+- Help/README/user guide updated with new flags; duplicate analysis now considers prefix patterns.
 
 ## [0.2.6] - 2025-11-22
 
@@ -1050,7 +1050,7 @@ This release dramatically reduces false positives in dead export detection acros
 - Default analyzer extensions now include `py`.
 
 ### Changed
-- README and Monika's guide updated with Python support.
+- README and user guide updated with Python support.
 
 ## [0.2.4] - 2025-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.8.16] - 2026-03-11
 
 ### Changed
-- Synced the public workspace with `loctree-suite` for `loctree_rs`, `loctree-mcp`, and `reports`.
+- Synced the public workspace with the upstream integration repository for `loctree_rs`, `loctree-mcp`, and `reports`.
 - Aligned the public root workspace contract to `0.8.16` and `rmcp 0.17` while keeping suite-only crates out of this repo.
 
 ### Fixed
@@ -55,7 +55,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 - Dependency updates: `oxc` `0.110 -> 0.113`, `rmcp` `0.12 -> 0.15`, `notify-debouncer-full` `0.6 -> 0.7`, and workspace `thiserror` alignment.
-- IDE docs updated with loctree-suite teaser banners for VSCode, Neovim, and LSP protocol pages.
+- IDE docs updated with the upstream integration repository's teaser banners for VSCode, Neovim, and LSP protocol pages.
 
 ### Removed
 - Workspace and script references to deprecated `loctree-server` and `loctree-lsp` components.
@@ -68,8 +68,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.8.12] - 2026-02-11
 
 ### Added
-- sync with loctree-suite v0.8.4
-- sync loctree_rs + loctree_server with loctree-suite
+- sync with the upstream integration repository v0.8.4
+- sync loctree_rs + loctree_server with the upstream integration repository
 - implement OXC-based AST parser for JS/TS
 - Add `loct` as short alias for `loctree` + clippy fixes (#39)
 
@@ -247,7 +247,7 @@ $ loct find recording_finalize_session transcription_finalize_stream session_not
 |------|----------------|
 | mlx-omni-server | 225 |
 | example-service | 899 |
-| loctree-suite | 862 |
+| the upstream integration repository | 862 |
 | example-app | 2362 |
 
 ## [0.8.3] - 2026-01-05

--- a/LICENSE
+++ b/LICENSE
@@ -12,14 +12,14 @@ https://mariadb.com/bsl11/
 Parameters
 ----------
 
-  Licensor:             Loctree Team (loct@loct.io)
+  Licensor:             Libraxis AI sp. z o.o. (contact@libraxis.ai)
 
   Licensed Work:        Loctree
                         - This repository (the upstream integration repository) and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.
-                        - Copyright (c) 2024-2026 Loctree Team.
+                        - Copyright (c) 2024-2026 Libraxis AI sp. z o.o.
 
   Additional Use Grant: You may make production use of the Licensed Work,
                         provided that your use does not include offering the

--- a/LICENSE
+++ b/LICENSE
@@ -15,7 +15,7 @@ Parameters
   Licensor:             Libraxis AI sp. z o.o. (contact@libraxis.ai)
 
   Licensed Work:        Loctree
-                        - This repository (the upstream integration repository) and all artifacts
+                        - This repository and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.

--- a/LICENSE
+++ b/LICENSE
@@ -15,7 +15,7 @@ Parameters
   Licensor:             Loctree Team (loct@loct.io)
 
   Licensed Work:        Loctree
-                        - This repository (loctree-suite) and all artifacts
+                        - This repository (the upstream integration repository) and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ If you discover a security vulnerability in Loctree, please report it responsibl
 
 **Do not open a public issue.**
 
-Instead, email: **security@loctree.dev**
+Instead, email: **security@loctree.com**
 
 We will acknowledge receipt within 48 hours and provide a timeline for a fix.
 

--- a/loctree-rs/LICENSE
+++ b/loctree-rs/LICENSE
@@ -12,14 +12,14 @@ https://mariadb.com/bsl11/
 Parameters
 ----------
 
-  Licensor:             Loctree Team (loct@loct.io)
+  Licensor:             Libraxis AI sp. z o.o. (contact@libraxis.ai)
 
   Licensed Work:        Loctree
                         - This repository (the upstream integration repository) and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.
-                        - Copyright (c) 2024-2026 Loctree Team.
+                        - Copyright (c) 2024-2026 Libraxis AI sp. z o.o.
 
   Additional Use Grant: You may make production use of the Licensed Work,
                         provided that your use does not include offering the

--- a/loctree-rs/LICENSE
+++ b/loctree-rs/LICENSE
@@ -15,7 +15,7 @@ Parameters
   Licensor:             Libraxis AI sp. z o.o. (contact@libraxis.ai)
 
   Licensed Work:        Loctree
-                        - This repository (the upstream integration repository) and all artifacts
+                        - This repository and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.

--- a/loctree-rs/LICENSE
+++ b/loctree-rs/LICENSE
@@ -15,7 +15,7 @@ Parameters
   Licensor:             Loctree Team (loct@loct.io)
 
   Licensed Work:        Loctree
-                        - This repository (loctree-suite) and all artifacts
+                        - This repository (the upstream integration repository) and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.

--- a/loctree-rs/src/aicx/shell.rs
+++ b/loctree-rs/src/aicx/shell.rs
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn parse_steer_handles_three_line_blocks() {
-        let payload = "Loctree/loctree-suite | claude | 2026-04-19 | conversations\n  run_id: -  prompt_id: -  model: -\n  /home/polyversai/.aicx/store/foo.md\n\nLoctree/loctree-suite | codex | 2026-04-25 | reports\n  run_id: mrbl-001  prompt_id: cut3-task  model: opus-4.7\n  /home/polyversai/.aicx/store/bar.md\n";
+        let payload = "Loctree/loctree-suite | claude | 2026-04-19 | conversations\n  run_id: -  prompt_id: -  model: -\n  /home/tester/.aicx/store/foo.md\n\nLoctree/loctree-suite | codex | 2026-04-25 | reports\n  run_id: mrbl-001  prompt_id: cut3-task  model: opus-4.7\n  /home/tester/.aicx/store/bar.md\n";
         let parsed = parse_steer(payload);
         assert_eq!(parsed.len(), 2);
 
@@ -628,7 +628,7 @@ mod tests {
         assert_eq!(parsed[1].model.as_deref(), Some("opus-4.7"));
         assert_eq!(
             parsed[1].source_chunk_path,
-            "/home/polyversai/.aicx/store/bar.md"
+            "/home/tester/.aicx/store/bar.md"
         );
     }
 

--- a/loctree-rs/src/analyzer/dead_parrots/mod.rs
+++ b/loctree-rs/src/analyzer/dead_parrots/mod.rs
@@ -1,6 +1,6 @@
 //! Dead Parrots Module - Janitor tools for code analysis and cleanup
 //!
-//! Named after the Monty Python sketch and the Vista project's "Dead Parrot Protocol"
+//! Named after the Monty Python sketch and the example-app project's "Dead Parrot Protocol"
 //! for identifying unused/dead code that "just resting" but is actually dead.
 //!
 //! This module contains:
@@ -2346,7 +2346,7 @@ mod tests {
 
     #[test]
     fn test_react_lazy_with_subdirectory_resolved_path() {
-        // Vista pattern: lazy(() => import('./features/patient/PasswordResetModal').then(...))
+        // example-app pattern: lazy(() => import('./features/patient/PasswordResetModal').then(...))
         // Component is in a subdirectory, import uses resolved_path via ImportKind::Dynamic
         let mut importer = mock_file("src/App.tsx");
         // Add dynamic import via ImportEntry with resolved_path (like real AST produces)
@@ -2385,7 +2385,7 @@ mod tests {
 
     #[test]
     fn test_react_lazy_named_export_via_then_pattern() {
-        // Vista pattern: lazy(() => import('./X').then((m) => ({ default: m.ComponentName })))
+        // example-app pattern: lazy(() => import('./X').then((m) => ({ default: m.ComponentName })))
         // This extracts a NAMED export and re-wraps it as default for React.lazy()
         // The file has NAMED export (not default), but it's still used via dynamic import
         let mut importer = mock_file("src/App.tsx");

--- a/loctree-rs/src/analyzer/dead_parrots/mod.rs
+++ b/loctree-rs/src/analyzer/dead_parrots/mod.rs
@@ -2346,20 +2346,20 @@ mod tests {
 
     #[test]
     fn test_react_lazy_with_subdirectory_resolved_path() {
-        // example-app pattern: lazy(() => import('./features/patient/PasswordResetModal').then(...))
+        // example-app pattern: lazy(() => import('./features/settings/PasswordResetModal').then(...))
         // Component is in a subdirectory, import uses resolved_path via ImportKind::Dynamic
         let mut importer = mock_file("src/App.tsx");
         // Add dynamic import via ImportEntry with resolved_path (like real AST produces)
         let mut dyn_import = ImportEntry::new(
-            "./features/patient/PasswordResetModal".to_string(),
+            "./features/settings/PasswordResetModal".to_string(),
             ImportKind::Dynamic,
         );
-        dyn_import.resolved_path = Some("src/features/patient/PasswordResetModal.tsx".to_string());
+        dyn_import.resolved_path = Some("src/features/settings/PasswordResetModal.tsx".to_string());
         importer.imports.push(dyn_import);
         // Also add to dynamic_imports for backward compat
-        importer.dynamic_imports = vec!["./features/patient/PasswordResetModal".to_string()];
+        importer.dynamic_imports = vec!["./features/settings/PasswordResetModal".to_string()];
 
-        let mut exporter = mock_file("src/features/patient/PasswordResetModal.tsx");
+        let mut exporter = mock_file("src/features/settings/PasswordResetModal.tsx");
         exporter.exports = vec![ExportSymbol {
             name: "PasswordResetModal".to_string(),
             kind: "function".to_string(),

--- a/loctree-rs/src/analyzer/env_truth/gha.rs
+++ b/loctree-rs/src/analyzer/env_truth/gha.rs
@@ -181,7 +181,7 @@ fn walk_strings<F: FnMut(&str)>(value: &Value, f: &mut F) {
 /// not attempt to track `GITHUB_ENV` / `$GITHUB_OUTPUT` propagation across
 /// steps — that is out of scope and architectural.
 ///
-/// W2-c assignment-scope predicate (Vista CI-vars regression): a `$VAR`
+/// W2-c assignment-scope predicate (example-app CI-vars regression): a `$VAR`
 /// reference counts as a read ONLY when no `run:` block in the same workflow
 /// assigns `VAR=` itself and VAR is not a runner-provided builtin
 /// (`GITHUB_*`, `RUNNER_*`, `CI`, ...). `BASE_REF="${1:-main}"` followed by
@@ -213,7 +213,7 @@ pub fn parse_workflow_shell_reads(path: &Path, root: &Path) -> Vec<(String, EnvR
 
     // Pass 1: collect shell-local assignments across every `run:` block in
     // the file (steps share a workflow file even if not a process — file
-    // scope keeps the predicate simple and kills the Vista false positives).
+    // scope keeps the predicate simple and kills the example-app false positives).
     let mut assigned: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for_each_run_block(jobs, &mut |run| {
         let cleaned = strip_gha_expressions(run);
@@ -417,7 +417,7 @@ jobs:
         );
     }
 
-    /// W2-c regression (Vista CI-vars): `BASE_REF` assigned inside the same
+    /// W2-c regression (example-app CI-vars): `BASE_REF` assigned inside the same
     /// workflow's `run:` block must not count as an env read, and runner
     /// builtins (`GITHUB_ENV`, `GITHUB_OUTPUT`, `RUNNER_OS`, `CI`) are
     /// never reads regardless of declarations.

--- a/loctree-rs/src/analyzer/env_truth/mod.rs
+++ b/loctree-rs/src/analyzer/env_truth/mod.rs
@@ -714,7 +714,7 @@ fn render_warning(w: &EnvWarning) -> String {
             sealed_age_days,
             plain_age_days,
         } => format!(
-            "sealed-secret-suspected-stale: `{}` is {}d old vs plain {}d — Vista pattern",
+            "sealed-secret-suspected-stale: `{}` is {}d old vs plain {}d — example-app pattern",
             sealed_path, sealed_age_days, plain_age_days
         ),
         EnvWarning::EncryptedDecodeBlocked { source } => {

--- a/loctree-rs/src/analyzer/env_truth/types.rs
+++ b/loctree-rs/src/analyzer/env_truth/types.rs
@@ -205,7 +205,7 @@ pub struct OrphanRead {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EnvWarning {
     /// A higher-precedence declaration is materially older than a
-    /// lower-precedence one. The classic Vista incident: stale SealedSecret
+    /// lower-precedence one. The classic example-app incident: stale SealedSecret
     /// (highest precedence, slow update cadence) overrides a freshly-edited
     /// `.env` / ConfigMap.
     StaleOverridesFresh {
@@ -228,7 +228,7 @@ pub enum EnvWarning {
     OrphanDeclaration { sources: Vec<String> },
     /// Specialization of `StaleOverridesFresh` for the SealedSecret/plain
     /// pair — emitted as a separate kind so CI gates can target the
-    /// Vista-style failure surface specifically.
+    /// example-app-style failure surface specifically.
     SealedSecretSuspectedStale {
         sealed_path: String,
         sealed_age_days: u32,

--- a/loctree-rs/src/analyzer/env_truth/warnings.rs
+++ b/loctree-rs/src/analyzer/env_truth/warnings.rs
@@ -81,7 +81,7 @@ pub fn compute_warnings(
     //    so `decl.sources[0]` wins at deploy time. The runner-up gives the
     //    canonical "obvious neighbor" comparison, but the SealedSecret/
     //    SOPS/ExternalSecret specialization scans **all** lower-rank
-    //    plain-bearing sources — Vista's case had a stale SealedSecret
+    //    plain-bearing sources — example-app's case had a stale SealedSecret
     //    overriding a fresh ConfigMap several layers down, not just the
     //    immediate runner-up.
     if decl.sources.len() >= 2 {
@@ -98,7 +98,7 @@ pub fn compute_warnings(
                     });
             }
         }
-        // Vista specialization: highest is sealed/sops/external AND any
+        // example-app specialization: highest is sealed/sops/external AND any
         // lower-rank plain-bearing source is materially fresher.
         if matches!(
             high.kind,

--- a/loctree-rs/src/analyzer/html.rs
+++ b/loctree-rs/src/analyzer/html.rs
@@ -283,7 +283,7 @@ mod tests {
 
         // Verify key parts exist in the Leptos-rendered output
         assert!(html.contains("<!DOCTYPE html>"));
-        assert!(html.contains("Loctree Report")); // Title in new Vista design
+        assert!(html.contains("Loctree Report")); // Title in new example-app design
 
         // The output format might differ slightly from legacy, check for content
         assert!(html.contains("Hint"));

--- a/loctree-rs/src/analyzer/occurrences.rs
+++ b/loctree-rs/src/analyzer/occurrences.rs
@@ -9,7 +9,7 @@
 //! — there are no fuzzy suggestions promoted as primary results, because a
 //! suggestion is not evidence.
 //!
-//! The CodeScribe `utterance_id` failure class is the canonical motivation: a
+//! The codescribe `utterance_id` failure class is the canonical motivation: a
 //! `let mut utterance_id` plus later `utterance_id += 1` increments living
 //! inside a 400-line function were invisible to `find`/`tagmap`. The literal
 //! scanner sees them because it does not depend on symbol extraction.

--- a/loctree-rs/src/analyzer/occurrences.rs
+++ b/loctree-rs/src/analyzer/occurrences.rs
@@ -506,9 +506,9 @@ fn is_false(b: &bool) -> bool {
 ///
 /// Default (`whole_token = false`) preserves the historical behavior exactly:
 /// `[A-Za-z0-9_]` are identifier-internal, so `backdrop` still matches inside
-/// the hyphenated CSS token `--vista-z-overlay-backdrop`. Opt-in
+/// the hyphenated CSS token `--sample-z-overlay-backdrop`. Opt-in
 /// `whole_token = true` additionally treats `-` as token-internal, so the same
-/// query no longer lights up `overlay-backdrop` / `--vista-z-overlay-backdrop`
+/// query no longer lights up `overlay-backdrop` / `--sample-z-overlay-backdrop`
 /// — the z-index noise the literal layer used to drag in.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ScanOptions {
@@ -566,7 +566,7 @@ fn is_ident_char(c: char) -> bool {
 
 /// Boundary test under a given [`ScanOptions`]. With `whole_token`, `-` also
 /// counts as token-internal, so a query like `backdrop` no longer matches
-/// inside `overlay-backdrop` / `--vista-z-overlay-backdrop`.
+/// inside `overlay-backdrop` / `--sample-z-overlay-backdrop`.
 #[inline]
 fn is_boundary_char(c: char, whole_token: bool) -> bool {
     is_ident_char(c) || (whole_token && c == '-')
@@ -2743,7 +2743,7 @@ mod tests {
 
     #[test]
     fn whole_token_excludes_hyphenated_neighbors() {
-        let line = "  z-index: var(--vista-z-overlay-backdrop);";
+        let line = "  z-index: var(--sample-z-overlay-backdrop);";
         // Default boundary: `backdrop` leaks into the hyphenated custom property.
         assert_eq!(occurrences_in_line_with(line, "backdrop", false).len(), 1);
         // whole_token: hyphen is token-internal, so the noisy hit disappears.
@@ -2758,7 +2758,7 @@ mod tests {
 
     #[test]
     fn scan_files_with_whole_token_drops_z_index_noise() {
-        let css = ".backdrop {}\n  --vista-z-overlay-backdrop: 40;";
+        let css = ".backdrop {}\n  --sample-z-overlay-backdrop: 40;";
         let loose = scan_files_with([("a.css", css)], "backdrop", ScanOptions::default());
         let tight = scan_files_with(
             [("a.css", css)],

--- a/loctree-rs/src/analyzer/pipelines.rs
+++ b/loctree-rs/src/analyzer/pipelines.rs
@@ -590,9 +590,9 @@ mod tests {
         // FE file with matching emit/listen
         let mut fe = FileAnalysis::new("src/frontend.ts".into());
         fe.event_emits
-            .push(mk_event("vista://ok", 10, "emit_literal", false));
+            .push(mk_event("sample://ok", 10, "emit_literal", false));
         fe.event_listens
-            .push(mk_event("vista://ok", 5, "listen_literal", true));
+            .push(mk_event("sample://ok", 5, "listen_literal", true));
         fe.command_calls.push(CommandRef {
             name: "unified_ai_chat".into(),
             exposed_name: None,
@@ -605,7 +605,7 @@ mod tests {
         // BE file emitting ghost event and handling command
         let mut be = FileAnalysis::new("src/backend.rs".into());
         be.event_emits
-            .push(mk_event("vista://ghost", 20, "emit_literal", false));
+            .push(mk_event("sample://ghost", 20, "emit_literal", false));
         be.command_handlers.push(CommandRef {
             name: "unified_ai_chat".into(),
             exposed_name: None,
@@ -626,7 +626,7 @@ mod tests {
             plugin_name: None,
         });
         racy.event_listens
-            .push(mk_event("vista://racy", 10, "listen_literal", false));
+            .push(mk_event("sample://racy", 10, "listen_literal", false));
 
         let analyses = vec![fe, be, racy];
         let summary = build_pipeline_summary(
@@ -645,12 +645,12 @@ mod tests {
         let ghost = events["ghostEmits"]
             .as_array()
             .expect("ghostEmits array present");
-        assert!(ghost.iter().any(|g| g["name"] == "vista://ghost"));
+        assert!(ghost.iter().any(|g| g["name"] == "sample://ghost"));
 
         let orphans = events["orphanListeners"]
             .as_array()
             .expect("orphanListeners array present");
-        assert!(orphans.iter().any(|o| o["name"] == "vista://racy"));
+        assert!(orphans.iter().any(|o| o["name"] == "sample://racy"));
 
         let chains = summary["commands"]["chains"]
             .as_array()

--- a/loctree-rs/src/analyzer/resolvers.rs
+++ b/loctree-rs/src/analyzer/resolvers.rs
@@ -293,10 +293,9 @@ impl TsPathResolver {
         // Strip $app/ or $env/ prefix
         let rest = if let Some(r) = normalized.strip_prefix("$app/") {
             format!("app/{}", r)
-        } else if let Some(r) = normalized.strip_prefix("$env/") {
-            format!("env/{}", r)
         } else {
-            return None;
+            let r = normalized.strip_prefix("$env/")?;
+            format!("env/{}", r)
         };
 
         // Try monorepo layout: packages/kit/src/runtime/{app|env}/...
@@ -325,10 +324,9 @@ impl TsPathResolver {
         // Strip $app/ or $env/ prefix
         let rest = if let Some(r) = normalized.strip_prefix("$app/") {
             format!("app/{}", r)
-        } else if let Some(r) = normalized.strip_prefix("$env/") {
-            format!("env/{}", r)
         } else {
-            return None;
+            let r = normalized.strip_prefix("$env/")?;
+            format!("env/{}", r)
         };
 
         // Try node_modules layout
@@ -365,11 +363,10 @@ impl TsPathResolver {
                 }
                 let captured = spec_rest.strip_suffix(part).unwrap_or(spec_rest);
                 captures.push(captured);
-            } else if let Some(idx) = spec_rest.find(part) {
+            } else {
+                let idx = spec_rest.find(part)?;
                 captures.push(&spec_rest[..idx]);
                 spec_rest = &spec_rest[idx + part.len()..];
-            } else {
-                return None;
             }
         }
 

--- a/loctree-rs/src/analyzer/scan.rs
+++ b/loctree-rs/src/analyzer/scan.rs
@@ -140,7 +140,7 @@ pub fn build_globset(patterns: &[String]) -> Option<GlobSet> {
 }
 
 pub fn opt_globset(globs: &[String]) -> Option<GlobSet> {
-    build_globset(globs).and_then(|g| if g.is_empty() { None } else { Some(g) })
+    build_globset(globs).filter(|g| !g.is_empty())
 }
 
 pub fn strip_excluded(files: &[String], exclude: &Option<GlobSet>) -> Vec<String> {

--- a/loctree-rs/src/analyzer/test_coverage.rs
+++ b/loctree-rs/src/analyzer/test_coverage.rs
@@ -238,7 +238,7 @@ fn analyze_handler_coverage(
         let frontend_calls = bridge.frontend_calls.len();
 
         // Find test imports for this handler
-        let handler_key = format!("{}::{}", backend_file, &bridge.name);
+        let handler_key = format!("{}::{}", backend_file, bridge.name);
         let test_imports: Vec<PathBuf> = symbol_coverage
             .get(&handler_key)
             .map(|set| set.iter().cloned().collect())
@@ -277,7 +277,7 @@ fn find_uncovered_exports(
 
     for file in prod_files {
         for export in &file.exports {
-            let coverage_key = format!("{}::{}", &file.path, &export.name);
+            let coverage_key = format!("{}::{}", file.path, export.name);
             let tested_by: Vec<PathBuf> = symbol_coverage
                 .get(&coverage_key)
                 .map(|set| set.iter().cloned().collect())

--- a/loctree-rs/src/cli/command/help_texts.rs
+++ b/loctree-rs/src/cli/command/help_texts.rs
@@ -1811,7 +1811,7 @@ OPTIONS:
     --help, -h                   Show this help message
 
 FAIL-ON KINDS:
-    stale-sealed-overrides-fresh-plain   The Vista pattern: stale SealedSecret/
+    stale-sealed-overrides-fresh-plain   The example-app pattern: stale SealedSecret/
                                          SOPS overrides a fresh dotenv/configmap.
     stale-overrides-fresh                Generic: highest-precedence is older
                                          than runner-up by stale-threshold-days.

--- a/loctree-rs/src/cli/command/help_texts.rs
+++ b/loctree-rs/src/cli/command/help_texts.rs
@@ -1292,7 +1292,7 @@ DESCRIPTION:
     Deps:       External files imported by core (outside the directory)
     Consumers:  Files outside the directory that import core files
 
-    Perfect for understanding feature modules like 'src/features/patients/'.
+    Perfect for understanding feature modules like 'src/features/settings/'.
 
 OPTIONS:
     --consumers, -c    Include files that import from this directory (default)
@@ -1306,17 +1306,17 @@ ARGUMENTS:
     <DIRECTORY>        Path to the directory to analyze (required)
 
 EXAMPLES:
-    loct focus src/features/patients/           # Focus + deps + consumers
+    loct focus src/features/settings/           # Focus + deps + consumers
     loct focus src/components/ --no-consumers   # Dependency-only view
     loct focus lib/utils/ --depth 1             # Limit external dep depth
     loct focus src/api/ --json                  # JSON output for AI tools
 
 OUTPUT FORMAT:
-    Focus: src/features/patients/
+    Focus: src/features/settings/
 
     Core (12 files, 2,340 LOC):
-      src/features/patients/index.ts
-      src/features/patients/PatientsList.tsx
+      src/features/settings/index.ts
+      src/features/settings/SettingsList.tsx
       ...
 
     Internal edges: 18 imports within directory
@@ -1495,7 +1495,7 @@ OUTPUT FORMAT:
       ...
 
     Orphan Files (0 importers, 2):
-      src/features/patients/PatientsList.tsx (504 LOC)
+      src/features/settings/SettingsList.tsx (504 LOC)
       src/components/deprecated/OldButton.tsx (89 LOC)
 
     Shadow Exports (1):

--- a/loctree-rs/src/cli/command/options.rs
+++ b/loctree-rs/src/cli/command/options.rs
@@ -236,7 +236,7 @@ pub struct FindOptions {
     pub offset: usize,
 
     /// Literal-mode: treat `-` as token-internal so `backdrop` does not match
-    /// inside `overlay-backdrop` / `--vista-z-overlay-backdrop`. Opt-in; the
+    /// inside `overlay-backdrop` / `--sample-z-overlay-backdrop`. Opt-in; the
     /// default boundary is unchanged. Ignored outside `--literal`.
     pub whole_token: bool,
 
@@ -265,7 +265,7 @@ pub struct OccurrencesOptions {
     pub roots: Vec<PathBuf>,
 
     /// Treat `-` as token-internal (tighter boundary) so `backdrop` does not
-    /// match inside `overlay-backdrop` / `--vista-z-overlay-backdrop`. Opt-in;
+    /// match inside `overlay-backdrop` / `--sample-z-overlay-backdrop`. Opt-in;
     /// the default boundary is unchanged.
     pub whole_token: bool,
 

--- a/loctree-rs/src/cli/dispatch/handlers/analysis.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/analysis.rs
@@ -1556,7 +1556,7 @@ pub fn handle_focus_command(opts: &FocusOptions, global: &GlobalOptions) -> Disp
         Some(f) => f,
         None => {
             // Distinguish a genuine wrong path from a correct path that is simply
-            // parked outside the snapshot by .loctignore (loctree-feedback.md: vista
+            // parked outside the snapshot by .loctignore (loctree-feedback.md: example-app
             // docs/). When the latter, lead with the precise cause instead of
             // telling the user to "check the path".
             let ignore_hint = crate::fs_utils::loctignore_exclusion_hint(root, &opts.target);

--- a/loctree-rs/src/cli/dispatch/handlers/context/pill.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/context/pill.rs
@@ -1637,7 +1637,8 @@ mod tests {
     #[test]
     fn pill_aicx_memory_does_not_leak_absolute_aicx_store_paths() {
         let mut pack = fixture_pack();
-        let leaky_path = "/home/polyversai/.aicx/store/Loctree/loctree-suite/2026_0525/conversations/claude/s1.md";
+        let leaky_path =
+            "/home/tester/.aicx/store/Loctree/loctree-suite/2026_0525/conversations/claude/s1.md";
         pack.memory = MemorySlice {
             entries: vec![MemoryEntry {
                 kind: "decision".to_string(),
@@ -1662,7 +1663,7 @@ mod tests {
         let input = input_with(&pack, &scope, AicxRenderStatus::EnabledWithRows);
         let md = render_pill(input);
         assert!(
-            !md.contains("/home/polyversai/.aicx/store/"),
+            !md.contains("/home/tester/.aicx/store/"),
             "absolute aicx-store path must NOT leak into rendered context: {md}"
         );
         assert!(

--- a/loctree-rs/src/cli/parser/analysis_commands.rs
+++ b/loctree-rs/src/cli/parser/analysis_commands.rs
@@ -217,7 +217,7 @@ OPTIONS:
                                         accounting + context labels. For secret/privacy audits where
                                         --literal cannot evaluate a pattern. Mutually exclusive with --literal.
     --whole-token                       (literal) Treat '-' as token-internal: 'backdrop' no longer matches
-                                        inside 'overlay-backdrop'/'--vista-z-overlay-backdrop' (opt-in, no default change)
+                                        inside 'overlay-backdrop'/'--sample-z-overlay-backdrop' (opt-in, no default change)
     --group-by-file                     (literal) Add a per-file occurrence rollup ('by_file')
     --count-only, --slim                (literal) Suppress the full occurrence list, keep counters only
     --offset <N>                        (literal) Zero-based occurrence offset for paged output
@@ -468,7 +468,7 @@ DESCRIPTION:
 OPTIONS:
     --root <PATH>        Project root to scan (default: current directory)
     --whole-token        Treat '-' as token-internal: 'backdrop' no longer matches inside
-                         'overlay-backdrop'/'--vista-z-overlay-backdrop' (opt-in, no default change)
+                         'overlay-backdrop'/'--sample-z-overlay-backdrop' (opt-in, no default change)
     --group-by-file      Add a per-file occurrence rollup ('by_file')
     --count-only, --slim Suppress the full occurrence list, keep counters only ('slim')
     --limit <N>          Maximum number of occurrences to return in this page

--- a/loctree-rs/src/focuser.rs
+++ b/loctree-rs/src/focuser.rs
@@ -530,24 +530,24 @@ mod tests {
                 git_scan_id: None,
             },
             files: vec![
-                // Files in src/features/patients/
+                // Files in src/features/settings/
                 FileAnalysis {
-                    path: "src/features/patients/index.ts".to_string(),
+                    path: "src/features/settings/index.ts".to_string(),
                     loc: 20,
                     language: "typescript".to_string(),
-                    ..FileAnalysis::new("src/features/patients/index.ts".to_string())
+                    ..FileAnalysis::new("src/features/settings/index.ts".to_string())
                 },
                 FileAnalysis {
-                    path: "src/features/patients/PatientsList.tsx".to_string(),
+                    path: "src/features/settings/SettingsList.tsx".to_string(),
                     loc: 150,
                     language: "typescript".to_string(),
-                    ..FileAnalysis::new("src/features/patients/PatientsList.tsx".to_string())
+                    ..FileAnalysis::new("src/features/settings/SettingsList.tsx".to_string())
                 },
                 FileAnalysis {
-                    path: "src/features/patients/usePatient.ts".to_string(),
+                    path: "src/features/settings/useSetting.ts".to_string(),
                     loc: 80,
                     language: "typescript".to_string(),
-                    ..FileAnalysis::new("src/features/patients/usePatient.ts".to_string())
+                    ..FileAnalysis::new("src/features/settings/useSetting.ts".to_string())
                 },
                 // External files
                 FileAnalysis {
@@ -570,32 +570,32 @@ mod tests {
                 },
             ],
             edges: vec![
-                // Internal edges (within patients/)
+                // Internal edges (within settings/)
                 GraphEdge {
-                    from: "src/features/patients/index.ts".to_string(),
-                    to: "src/features/patients/PatientsList.tsx".to_string(),
+                    from: "src/features/settings/index.ts".to_string(),
+                    to: "src/features/settings/SettingsList.tsx".to_string(),
                     label: "reexport".to_string(),
                 },
                 GraphEdge {
-                    from: "src/features/patients/PatientsList.tsx".to_string(),
-                    to: "src/features/patients/usePatient.ts".to_string(),
+                    from: "src/features/settings/SettingsList.tsx".to_string(),
+                    to: "src/features/settings/useSetting.ts".to_string(),
                     label: "import".to_string(),
                 },
-                // External deps (patients imports external)
+                // External deps (settings imports external)
                 GraphEdge {
-                    from: "src/features/patients/PatientsList.tsx".to_string(),
+                    from: "src/features/settings/SettingsList.tsx".to_string(),
                     to: "src/components/Button.tsx".to_string(),
                     label: "import".to_string(),
                 },
                 GraphEdge {
-                    from: "src/features/patients/usePatient.ts".to_string(),
+                    from: "src/features/settings/useSetting.ts".to_string(),
                     to: "src/utils/api.ts".to_string(),
                     label: "import".to_string(),
                 },
-                // Consumer (App imports patients)
+                // Consumer (App imports settings)
                 GraphEdge {
                     from: "src/App.tsx".to_string(),
-                    to: "src/features/patients/index.ts".to_string(),
+                    to: "src/features/settings/index.ts".to_string(),
                     label: "import".to_string(),
                 },
             ],
@@ -613,10 +613,10 @@ mod tests {
         let snapshot = create_test_snapshot();
         let config = FocusConfig::default();
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
-            .expect("focus on patients");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
+            .expect("focus on settings");
 
-        assert_eq!(focus.target, "src/features/patients");
+        assert_eq!(focus.target, "src/features/settings");
         assert_eq!(focus.stats.core_files, 3);
         assert_eq!(focus.stats.core_loc, 250); // 20 + 150 + 80
     }
@@ -626,10 +626,10 @@ mod tests {
         let snapshot = create_test_snapshot();
         let config = FocusConfig::default();
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
-            .expect("focus on patients");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
+            .expect("focus on settings");
 
-        // Two internal edges: index->PatientsList, PatientsList->usePatient
+        // Two internal edges: index->SettingsList, SettingsList->useSetting
         assert_eq!(focus.stats.internal_edges, 2);
     }
 
@@ -638,10 +638,10 @@ mod tests {
         let snapshot = create_test_snapshot();
         let config = FocusConfig::default();
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
-            .expect("focus on patients");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
+            .expect("focus on settings");
 
-        // PatientsList imports Button, usePatient imports api
+        // SettingsList imports Button, useSetting imports api
         assert_eq!(focus.stats.deps_files, 2);
         let dep_paths: Vec<_> = focus.deps.iter().map(|f| f.path.as_str()).collect();
         assert!(dep_paths.contains(&"src/components/Button.tsx"));
@@ -654,10 +654,10 @@ mod tests {
         let index = snapshot
             .files
             .iter_mut()
-            .find(|file| file.path == "src/features/patients/index.ts")
+            .find(|file| file.path == "src/features/settings/index.ts")
             .expect("fixture index.ts");
         index.exports.push(crate::types::ExportSymbol {
-            name: "PatientsModule".to_string(),
+            name: "SettingsModule".to_string(),
             kind: "function".to_string(),
             export_type: "named".to_string(),
             line: Some(3),
@@ -667,10 +667,10 @@ mod tests {
 
         let focus = HolographicFocus::from_path(
             &snapshot,
-            "src/features/patients",
+            "src/features/settings",
             &FocusConfig::default(),
         )
-        .expect("focus on patients");
+        .expect("focus on settings");
         let json = focus.to_json();
 
         assert_eq!(
@@ -684,8 +684,8 @@ mod tests {
                 .expect("coreSymbols")
                 .iter()
                 .any(|symbol| {
-                    symbol["name"] == "PatientsModule"
-                        && symbol["file"] == "src/features/patients/index.ts"
+                    symbol["name"] == "SettingsModule"
+                        && symbol["file"] == "src/features/settings/index.ts"
                         && symbol["line"] == 3
                         && symbol["authority"] == "LoctreeDerived"
                 }),
@@ -696,7 +696,7 @@ mod tests {
                 .as_array()
                 .expect("suggestedNext")
                 .iter()
-                .any(|step| step["command"] == "loct occurrences 'PatientsModule' --json"),
+                .any(|step| step["command"] == "loct occurrences 'SettingsModule' --json"),
             "focus should carry non-empty suggested next steps: {json}"
         );
     }
@@ -709,10 +709,10 @@ mod tests {
             ..Default::default()
         };
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
-            .expect("focus on patients with consumers");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
+            .expect("focus on settings with consumers");
 
-        // App.tsx imports from patients
+        // App.tsx imports from settings
         assert_eq!(focus.stats.consumers_files, 1);
         assert_eq!(focus.consumers[0].path, "src/App.tsx");
     }
@@ -732,9 +732,9 @@ mod tests {
         let config = FocusConfig::default();
 
         // All these should work the same
-        let f1 = HolographicFocus::from_path(&snapshot, "src/features/patients", &config);
-        let f2 = HolographicFocus::from_path(&snapshot, "src/features/patients/", &config);
-        let f3 = HolographicFocus::from_path(&snapshot, "./src/features/patients", &config);
+        let f1 = HolographicFocus::from_path(&snapshot, "src/features/settings", &config);
+        let f2 = HolographicFocus::from_path(&snapshot, "src/features/settings/", &config);
+        let f3 = HolographicFocus::from_path(&snapshot, "./src/features/settings", &config);
 
         assert!(f1.is_some());
         assert!(f2.is_some());

--- a/loctree-rs/src/fs_utils.rs
+++ b/loctree-rs/src/fs_utils.rs
@@ -516,7 +516,7 @@ fn matchers_exclude(matchers: &IgnoreMatchers, abs_path: &Path) -> bool {
 /// not loctignore-excluded. This lets callers (focus / slice) distinguish
 /// "wrong path — check it" from "right path, but parked outside the snapshot by
 /// .loctignore", instead of misleadingly telling the user to check a path that
-/// is in fact correct (loctree-feedback.md: vista `docs/` excluded by .loctignore).
+/// is in fact correct (loctree-feedback.md: example-app `docs/` excluded by .loctignore).
 pub fn loctignore_exclusion_hint(root: &Path, target: &str) -> Option<String> {
     let abs = root.join(target);
     if !abs.exists() {
@@ -1613,7 +1613,7 @@ mod tests {
 
     #[test]
     fn loctignore_exclusion_hint_distinguishes_ignored_from_wrong_path() {
-        // loctree-feedback.md (2026-06-25, vista): focus(docs)/slice fell back with
+        // loctree-feedback.md (2026-06-25, example-app): focus(docs)/slice fell back with
         // "No files found. Check the path." when docs/ EXISTS on disk but is
         // excluded by .loctignore. The hint must name .loctignore so the agent
         // does not chase a wrong-path that is actually correct.

--- a/loctree-rs/src/semantic/shell.rs
+++ b/loctree-rs/src/semantic/shell.rs
@@ -1181,7 +1181,7 @@ echo "${LANG:-en_US.UTF-8}"
 
     #[test]
     fn env_contract_skips_locally_assigned_uppercase_vars() {
-        // W2-c regression (CodeScribe 126 / suite 152 false orphans):
+        // W2-c regression (codescribe 126 / suite 152 false orphans):
         // `APP_NAME=x` + `echo $APP_NAME` is a script-local variable, not an
         // env contract. Same for ANSI color locals and loop variables.
         let tmp = tempfile::tempdir().unwrap();

--- a/loctree-rs/src/snapshot.rs
+++ b/loctree-rs/src/snapshot.rs
@@ -5712,20 +5712,20 @@ mod cache_tests {
     #[test]
     fn snapshot_parse_owner_repo_https() {
         assert_eq!(
-            parse_owner_repo("https://github.com/polyversai/loctree.git"),
-            Some("polyversai/loctree".to_string()),
+            parse_owner_repo("https://github.com/Loctree/loctree.git"),
+            Some("Loctree/loctree".to_string()),
         );
         assert_eq!(
-            parse_owner_repo("https://github.com/polyversai/loctree"),
-            Some("polyversai/loctree".to_string()),
+            parse_owner_repo("https://github.com/Loctree/loctree"),
+            Some("Loctree/loctree".to_string()),
         );
     }
 
     #[test]
     fn snapshot_parse_owner_repo_ssh() {
         assert_eq!(
-            parse_owner_repo("git@github.com:polyversai/loctree.git"),
-            Some("polyversai/loctree".to_string()),
+            parse_owner_repo("git@github.com:Loctree/loctree.git"),
+            Some("Loctree/loctree".to_string()),
         );
         assert_eq!(
             parse_owner_repo("git@gitlab.example.com:org/sub-repo.git"),
@@ -5746,11 +5746,11 @@ mod cache_tests {
     #[test]
     fn snapshot_parse_repo_name_extracts_last_segment() {
         assert_eq!(
-            parse_repo_name("https://github.com/polyversai/loctree.git"),
+            parse_repo_name("https://github.com/Loctree/loctree.git"),
             Some("loctree".to_string()),
         );
         assert_eq!(
-            parse_repo_name("git@github.com:polyversai/loctree.git"),
+            parse_repo_name("git@github.com:Loctree/loctree.git"),
             Some("loctree".to_string()),
         );
     }
@@ -5810,7 +5810,7 @@ mod cache_tests {
             entrypoints: Vec::new(),
             entrypoint_drift: EntrypointDriftSummary::default(),
             git_repo: Some("loctree".to_string()),
-            git_owner_repo: Some("polyversai/loctree".to_string()),
+            git_owner_repo: Some("Loctree/loctree".to_string()),
             git_branch: Some("main".to_string()),
             git_commit: Some("d6ecd24".to_string()),
             git_scan_id: Some("main@d6ecd24".to_string()),
@@ -5820,7 +5820,7 @@ mod cache_tests {
         let deser: SnapshotMetadata = serde_json::from_str(&json).expect("deserialize");
 
         assert_eq!(deser.git_repo, Some("loctree".to_string()));
-        assert_eq!(deser.git_owner_repo, Some("polyversai/loctree".to_string()));
+        assert_eq!(deser.git_owner_repo, Some("Loctree/loctree".to_string()));
         assert_eq!(deser.git_branch, Some("main".to_string()));
         assert_eq!(deser.git_commit, Some("d6ecd24".to_string()));
     }

--- a/loctree-rs/tests/e2e_cli.rs
+++ b/loctree-rs/tests/e2e_cli.rs
@@ -4291,10 +4291,7 @@ mod management_commands {
             "report must start with DOCTYPE, got first chars: {:?}",
             &html.chars().take(40).collect::<String>()
         );
-        assert!(
-            html.contains("Loctree Report"),
-            "missing Vista report title"
-        );
+        assert!(html.contains("Loctree Report"), "missing report title");
         assert!(
             html.contains(env!("CARGO_PKG_VERSION")),
             "missing loctree binary version ({}) in rendered provenance chip",
@@ -7411,7 +7408,7 @@ mod dead_truth {
         );
     }
 
-    /// Empiria: Vista lazy-import `import('./Steps').then((m) => m.InviteTeamStep)`
+    /// Empiria: example-app lazy-import `import('./Steps').then((m) => m.InviteTeamStep)`
     /// — the named export consumed only through the dynamic-import member
     /// access must not be dead.
     #[test]

--- a/loctree-rs/tests/e2e_cli.rs
+++ b/loctree-rs/tests/e2e_cli.rs
@@ -7424,7 +7424,7 @@ mod dead_truth {
         );
     }
 
-    /// Empiria: CodeScribe stt-bridge — runtime entry files spawned only by
+    /// Empiria: codescribe stt-bridge — runtime entry files spawned only by
     /// string. The fixture carries BOTH a Cargo [[bin]]
     /// (`src/bin/stt_bridge.rs`) and a package.json bin
     /// (`daemon/voice_daemon.js`, spawned via `spawn('voice-daemon')`).

--- a/loctree-rs/tests/e2e_cli.rs
+++ b/loctree-rs/tests/e2e_cli.rs
@@ -5435,13 +5435,13 @@ mod env_truth {
         assert!(stdout.contains("sha256:"));
     }
 
-    /// W2-c: default report stays small even on a CodeScribe-like surface
+    /// W2-c: default report stays small even on a codescribe-like surface
     /// (the 2026-line wall regression).
     #[test]
     fn default_report_is_bounded_under_200_lines() {
         let temp = TempDir::new().unwrap();
         stage_env_drift(&temp, 30, 2);
-        // Add a CodeScribe-like pile of one-off declarations to fatten the
+        // Add a codescribe-like pile of one-off declarations to fatten the
         // would-be full dump.
         let mut extra = String::new();
         for i in 0..120 {
@@ -5665,7 +5665,7 @@ mod env_truth {
 mod occurrences_cli {
     use super::*;
 
-    /// W1-A regression — the CodeScribe `utterance_id` failure class.
+    /// W1-A regression — the codescribe `utterance_id` failure class.
     ///
     /// `loct occurrences <ident>` must find LOCAL-variable occurrences buried
     /// inside a large function — exactly the case `find`/`tagmap` missed (they
@@ -6247,7 +6247,7 @@ mod find_literal_cli {
     /// `loct find --literal <ident> --json` must return a `literal_matches`
     /// section whose occurrences are byte-for-byte the same lines `loct
     /// occurrences` surfaces — every result tagged `source: "literal"`, and the
-    /// buried-local CodeScribe lines (`let mut utterance_id`, `utterance_id += 1`)
+    /// buried-local codescribe lines (`let mut utterance_id`, `utterance_id += 1`)
     /// present. This is the W1-B acceptance: when the mode says literal, the
     /// answer is literal.
     #[test]

--- a/loctree-rs/tests/e2e_cli.rs
+++ b/loctree-rs/tests/e2e_cli.rs
@@ -4289,7 +4289,7 @@ mod management_commands {
         assert!(
             html.contains("<!DOCTYPE html>"),
             "report must start with DOCTYPE, got first chars: {:?}",
-            &html.chars().take(40).collect::<String>()
+            html.chars().take(40).collect::<String>()
         );
         assert!(html.contains("Loctree Report"), "missing report title");
         assert!(
@@ -4320,7 +4320,7 @@ mod management_commands {
                 html.contains(needle),
                 "fixture-derived fact '{}' missing from HTML; first 500 chars: {:?}",
                 needle,
-                &html.chars().take(500).collect::<String>()
+                html.chars().take(500).collect::<String>()
             );
         }
 

--- a/loctree-rs/tests/e2e_cli.rs
+++ b/loctree-rs/tests/e2e_cli.rs
@@ -6655,7 +6655,7 @@ mod occurrences_quality_cli {
     }
 
     /// `--whole-token` tightens the boundary so `backdrop` stops matching inside
-    /// hyphenated neighbors (`--vista-z-overlay-backdrop`, `backdrop-filter`),
+    /// hyphenated neighbors (`--sample-z-overlay-backdrop`, `backdrop-filter`),
     /// cutting the z-index noise — while the default boundary is unchanged.
     #[test]
     fn whole_token_cuts_hyphenated_noise() {
@@ -6673,7 +6673,7 @@ mod occurrences_quality_cli {
         assert!(
             tight_occ.iter().all(|o| {
                 let ctx = o["context"].as_str().unwrap_or("");
-                !ctx.contains("--vista-z-overlay-backdrop")
+                !ctx.contains("--sample-z-overlay-backdrop")
             }) || tight_occ.iter().all(|o| o["matched_text"] == "backdrop"),
             "whole_token must not surface a hit *inside* the hyphenated custom property"
         );
@@ -6682,9 +6682,9 @@ mod occurrences_quality_cli {
             !tight_occ.iter().any(|o| o["context"]
                 .as_str()
                 .unwrap_or("")
-                .contains("--vista-z-overlay-backdrop")
+                .contains("--sample-z-overlay-backdrop")
                 && o["occurrence_kind"] == "custom_property"),
-            "the `--vista-z-overlay-backdrop` noise hit must be gone under whole_token"
+            "the `--sample-z-overlay-backdrop` noise hit must be gone under whole_token"
         );
     }
 
@@ -6755,7 +6755,7 @@ mod occurrences_quality_cli {
         fs::create_dir_all(&subdir).unwrap();
         fs::write(
             subdir.join("styles.css"),
-            "/* backdrop */\n.backdrop { --vista-z-overlay-backdrop: 40; }\n",
+            "/* backdrop */\n.backdrop { --sample-z-overlay-backdrop: 40; }\n",
         )
         .unwrap();
         fs::write(

--- a/loctree-rs/tests/fixtures/dead_truth_lazy/src/App.tsx
+++ b/loctree-rs/tests/fixtures/dead_truth_lazy/src/App.tsx
@@ -1,4 +1,4 @@
-// Vista pattern: React.lazy() extracting a NAMED export from a dynamic import.
+// example-app pattern: React.lazy() extracting a NAMED export from a dynamic import.
 const InviteTeam = () =>
   import('./Steps').then((m) => ({ default: m.InviteTeamStep }));
 

--- a/loctree-rs/tests/fixtures/dead_truth_spawn/src/lib.rs
+++ b/loctree-rs/tests/fixtures/dead_truth_spawn/src/lib.rs
@@ -1,5 +1,5 @@
 //! Spawner side: references the bridge binary only by its string name —
-//! the CodeScribe stt-bridge empiria (file "dead" in the graph, alive at
+//! the codescribe stt-bridge empiria (file "dead" in the graph, alive at
 //! runtime via Command::new("stt-bridge")).
 
 pub fn spawn_bridge() -> std::io::Result<std::process::Child> {

--- a/loctree-rs/tests/fixtures/env_drift/.env
+++ b/loctree-rs/tests/fixtures/env_drift/.env
@@ -1,5 +1,5 @@
 # Fresh local credentials — operator has just rotated DATABASE_URL.
 # Compare against k8s/sealed-secret.yaml: same key, stale ciphertext.
-DATABASE_URL=postgres://fresh-credentials@localhost:5432/vista
+DATABASE_URL=postgres://fresh-credentials@localhost:5432/example_app
 API_KEY=fresh-rotated-key-2026
 LOG_LEVEL=info

--- a/loctree-rs/tests/fixtures/env_drift/README.md
+++ b/loctree-rs/tests/fixtures/env_drift/README.md
@@ -1,6 +1,6 @@
 # env_drift fixture (Cut 8 / Lane 4)
 
-Synthesises the Vista April-2026 incident pattern.
+Synthesises the example-app April-2026 incident pattern.
 
 - `.env` — fresh local credentials (operator just rotated `DATABASE_URL`).
 - `k8s/sealed-secret.yaml` — production SealedSecret with **stale** ciphertext

--- a/loctree-rs/tests/fixtures/env_drift/docker-compose.yml
+++ b/loctree-rs/tests/fixtures/env_drift/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   api:
-    image: vista/api
+    image: example-app/api
     environment:
-      DATABASE_URL: postgres://compose-host:5432/vista
+      DATABASE_URL: postgres://compose-host:5432/example-app
       LOG_LEVEL: debug
     env_file:
       - ./.env

--- a/loctree-rs/tests/fixtures/env_drift/k8s/configmap.yaml
+++ b/loctree-rs/tests/fixtures/env_drift/k8s/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vista-config
+  name: example-app-config
   namespace: production
 data:
-  DATABASE_URL: postgres://other-host@db.svc:5432/vista
+  DATABASE_URL: postgres://other-host@db.svc:5432/example-app
   LOG_LEVEL: info
   FEATURE_FLAGS: '{"x":true}'

--- a/loctree-rs/tests/fixtures/env_drift/k8s/deployment.yaml
+++ b/loctree-rs/tests/fixtures/env_drift/k8s/deployment.yaml
@@ -1,29 +1,29 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vista-api
+  name: example-app-api
   namespace: production
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vista-api
+      app: example-app-api
   template:
     metadata:
       labels:
-        app: vista-api
+        app: example-app-api
     spec:
       containers:
         - name: api
-          image: ghcr.io/vista/api:latest
+          image: ghcr.io/example-app/api:latest
           env:
             - name: NODE_ENV
               value: production
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: vista-credentials
+                  name: example-app-credentials
                   key: DATABASE_URL
           envFrom:
             - configMapRef:
-                name: vista-config
+                name: example-app-config

--- a/loctree-rs/tests/fixtures/env_drift/k8s/sealed-secret.yaml
+++ b/loctree-rs/tests/fixtures/env_drift/k8s/sealed-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: vista-credentials
+  name: example-app-credentials
   namespace: production
 spec:
   encryptedData:
@@ -9,5 +9,5 @@ spec:
     API_KEY: AgC9pPmRQOyU9k0zKr4n0dXyL6qGw7tMnOvWyYABnZlCeStDgIxHrV0L8pOcWyZfJqKbDeGhRsUzNoWcDeFhRsUzNoWcDeFhRsUzNoWcDeFh==
   template:
     metadata:
-      name: vista-credentials
+      name: example-app-credentials
     type: Opaque

--- a/loctree-rs/tests/fixtures/occurrences_backdrop/styles.css
+++ b/loctree-rs/tests/fixtures/occurrences_backdrop/styles.css
@@ -1,5 +1,5 @@
 /* backdrop styling tokens */
 .backdrop {
   backdrop-filter: blur(2px);
-  --vista-z-overlay-backdrop: 40;
+  --sample-z-overlay-backdrop: 40;
 }

--- a/loctree-rs/tests/fixtures/occurrences_local_idents/src/lib.rs
+++ b/loctree-rs/tests/fixtures/occurrences_local_idents/src/lib.rs
@@ -1,4 +1,4 @@
-//! Fixture reproducing the CodeScribe `utterance_id` failure class.
+//! Fixture reproducing the codescribe `utterance_id` failure class.
 //!
 //! `utterance_id` is a *local* variable initialized and incremented deep
 //! inside a large function body — plus emitted as a struct field. AST/tagmap


### PR DESCRIPTION
## What this PR does

De-privatization pass (r2) for public release: removes private fingerprints from tracked content — private product references, home paths, personal names, and org-mismatched contact data.

This branch was rebuilt on top of current `main` after the 0.13.0 engine re-sync (#59, #60) rewrote most of the tree and made the original 2026-06-28 scrub conflict. The previous head (7 commits) was superseded; most of its findings became moot because the re-sync deleted their targets (`docs/use-cases/` incl. the private case-study doc, `.vibecrafted/GUIDELINES.md`, vendored reports, VSCode extension config).

## Commits

- `6d7e829` changelog: private names/labels genericized
- `2337ee3` SECURITY: security contact aligned with Loctree org domain (`security@loctree.com`)
- `5a16a60` tests: private home path replaced with neutral placeholder
- `d540048` examples/fixtures: private product references renamed (`sample://` scheme, `--sample-z-*` CSS token, `example-app-*` k8s fixtures) — coupled with test assertions
- `8b61685` residual product-name references scrubbed from CLI help text, runtime warning string, and comments

## Gates

- `cargo fmt --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test --workspace --no-fail-fast` — all green (e2e suite 255/255 on the coupled renames)

## Scanner / verify / history

- Layer A scanner + fingerprint rescan: remaining tracked-content PII after this branch — 0
- `deprivatize.py verify` — clean
- `history-scan` (report-only) — 0 flagged commits

## Review notes

- Unresolved items requiring operator decisions (CI runner labels, upstream-mirror scrubs, legal identity strings) are tracked in the internal decisions file, not silently changed here. No load-bearing identifiers were partially renamed.
- Note for maintainers: `loctree-rs/` + `loctree-ast/` are a release mirror synced from the upstream integration repo (see `SYNC-MANIFEST.md` / `NOTICE.md`). The scrubs in those paths must be replicated upstream, otherwise the next engine sync will revert them. The replication list is tracked internally.
