### PR TITLE
chore: add glama.json maintainer manifest for Glama claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "div0-space"
+  ]
+}


### PR DESCRIPTION
Glama.ai auto-indexes this repo as an MCP server, but the server page was never claimed. Claiming requires a `glama.json` at repo root listing the maintainer GitHub login (`div0-space`), then "Login with GitHub to claim" on glama.ai.

Source of truth lives in loctree-suite (commit e83cfbce); this PR imports the manifest to the public mirror. The file sits outside the sync payload (`loctree-rs`/`loctree-ast`), so future snapshot re-syncs will not remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)