### PR TITLE
release: 0.13.1 snapshot sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "aicx"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fda9eb391a89ce5572cca0e04aa89e37cfc60721832b028457b595c76ac761"
+dependencies = [
+ "aicx-parser",
+ "anyhow",
+ "blake3",
+ "chrono",
+ "dirs",
+ "getrandom 0.3.4",
+ "globset",
+ "hex",
+ "libc",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "shlex 1.3.0",
+ "siphasher",
+ "toml 0.8.23",
+ "tracing",
+]
+
+[[package]]
+name = "aicx-parser"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd45260b57074d771dc5ab864c7aa2d2ae3ac464e9558942e1653cfb7657945"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dirs",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "toml 0.8.23",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +93,18 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -153,6 +210,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,14 +281,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -304,8 +375,8 @@ dependencies = [
  "convert_case 0.6.0",
  "pathdiff",
  "serde_core",
- "toml",
- "winnow",
+ "toml 1.1.2+spec-1.1.0",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -358,6 +429,12 @@ name = "const_str_slice_concat"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67855af358fcb20fac58f9d714c94e2b228fe5694c1c9b4ead4a366343eda1b"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -840,13 +917,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -929,6 +1018,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hifijson"
@@ -1231,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -1247,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1258,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -1534,8 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "loctree"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
+ "aicx",
  "anyhow",
  "assert_cmd",
  "chrono",
@@ -1577,7 +1673,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
@@ -1590,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "loctree-ast"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "thiserror 2.0.18",
  "tree-sitter",
@@ -2344,6 +2440,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2444,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2456,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2479,9 +2581,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "report-leptos"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4ce71b72301605c571da75d0e63331c3c5dc4d6f4071ad383d9a690c110f79"
+checksum = "3a18f82c8d8d6aa81ac89a2d2d832bd365a33ec81604d0ae8e942455d77e0d3d"
 dependencies = [
  "leptos",
  "serde",
@@ -2716,6 +2818,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -2841,6 +2952,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -3101,6 +3218,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,17 +3284,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3175,13 +3328,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3367,6 +3540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3649,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3855,12 +4046,27 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.91.1"
 license = "BUSL-1.1"
 authors = ["Loctree <loct@loct.io>"]
 
@@ -35,6 +35,7 @@ shellexpand = "3.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-native-roots"] }
 sha2 = "0.10"
 schemars = "1"
-loctree = { path = "loctree-rs", version = "0.13.0" }
-loctree-ast = { path = "loctree-ast", version = "0.13.0" }
-report-leptos = "0.13.0"
+aicx = { version = "0.10.0", default-features = false, features = ["loctree-consumer"] }
+loctree = { path = "loctree-rs", version = "0.13.1" }
+loctree-ast = { path = "loctree-ast", version = "0.13.1" }
+report-leptos = "0.13.1"

--- a/LICENSE
+++ b/LICENSE
@@ -12,14 +12,14 @@ https://mariadb.com/bsl11/
 Parameters
 ----------
 
-  Licensor:             Libraxis AI sp. z o.o. (contact@libraxis.ai)
+  Licensor:             Loctree Team (loct@loct.io)
 
   Licensed Work:        Loctree
-                        - This repository and all artifacts
+                        - This repository (loctree-suite) and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.
-                        - Copyright (c) 2024-2026 Libraxis AI sp. z o.o.
+                        - Copyright (c) 2024-2026 Loctree Team.
 
   Additional Use Grant: You may make production use of the Licensed Work,
                         provided that your use does not include offering the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Loctree Engine 0.13.0
+# Loctree Engine 0.13.1
 
 This repository is the public release mirror for the Loctree engine.
 

--- a/SYNC-MANIFEST.md
+++ b/SYNC-MANIFEST.md
@@ -1,10 +1,10 @@
 # Component Sync Manifest
 
 - Component: `engine`
-- Version: `0.13.0`
+- Version: `0.13.1`
 - Target repo: `Loctree/loctree`
-- Source commit: `a38afb8aba01`
-- Generated at: `2026-07-08T21:47:10Z`
+- Source commit: `53cf52c1728b`
+- Generated at: `2026-07-12T05:17:28Z`
 - Push mode: `disabled`
 - Dependency mode: `crates.io registry`
 

--- a/loctree-rs/Cargo.toml
+++ b/loctree-rs/Cargo.toml
@@ -29,6 +29,7 @@ name = "loct"
 path = "src/bin/loct.rs"
 
 [dependencies]
+aicx = { workspace = true, optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -111,7 +112,8 @@ regex = "1.12"
 serial_test = "3.2"
 
 [features]
-default = []
+default = ["aicx-inprocess"]
+aicx-inprocess = ["dep:aicx"]
 deep-index = ["dep:prost"]
 # macOS-only Swift/Objective-C deep mode. The feature gates an opportunistic
 # reader for existing Apple IndexStore data; non-macOS builds compile it out.

--- a/loctree-rs/LICENSE
+++ b/loctree-rs/LICENSE
@@ -12,14 +12,14 @@ https://mariadb.com/bsl11/
 Parameters
 ----------
 
-  Licensor:             Libraxis AI sp. z o.o. (contact@libraxis.ai)
+  Licensor:             Loctree Team (loct@loct.io)
 
   Licensed Work:        Loctree
-                        - This repository and all artifacts
+                        - This repository (loctree-suite) and all artifacts
                           published from it: loct, loctree-mcp, loctree-lsp,
                           the loctree library crate, report-leptos,
                           rmcp-common, and the loctree-landing site.
-                        - Copyright (c) 2024-2026 Libraxis AI sp. z o.o.
+                        - Copyright (c) 2024-2026 Loctree Team.
 
   Additional Use Grant: You may make production use of the Licensed Work,
                         provided that your use does not include offering the

--- a/loctree-rs/src/aicx/inprocess.rs
+++ b/loctree-rs/src/aicx/inprocess.rs
@@ -1,0 +1,113 @@
+use super::{AicxIntent, ProjectScope};
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub enum AicxInProcessError {
+    TimedOut,
+    Other(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub struct AicxInProcessClient {
+    client: aicx::api::Aicx,
+}
+
+impl AicxInProcessClient {
+    pub fn from_env() -> Result<Self, anyhow::Error> {
+        let base = aicx::api::Aicx::from_env()?;
+        let store_root = base.store_root().join("store");
+        Ok(Self {
+            client: aicx::api::Aicx::with_store_root(store_root),
+        })
+    }
+
+    pub fn intents(
+        &self,
+        scope: &ProjectScope,
+        window_hours: u64,
+        limit: usize,
+        cap: Option<Duration>,
+    ) -> Result<Vec<AicxIntent>, AicxInProcessError> {
+        let Some(cap) = cap else {
+            return self
+                .intents_unbounded(scope, window_hours, limit)
+                .map_err(AicxInProcessError::Other);
+        };
+
+        let scope = scope.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = Self::from_env()
+                .and_then(|client| client.intents_unbounded(&scope, window_hours, limit));
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(cap) {
+            Ok(Ok(rows)) => Ok(rows),
+            Ok(Err(error)) => Err(AicxInProcessError::Other(error)),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(AicxInProcessError::TimedOut),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(AicxInProcessError::Other(
+                anyhow::anyhow!("in-process AICX worker disconnected"),
+            )),
+        }
+    }
+
+    fn intents_unbounded(
+        &self,
+        scope: &ProjectScope,
+        window_hours: u64,
+        limit: usize,
+    ) -> Result<Vec<AicxIntent>, anyhow::Error> {
+        let mut config = aicx::intents::IntentsConfig {
+            project: scope.primary().to_string(),
+            hours: window_hours,
+            strict: false,
+            min_confidence: None,
+            kind_filter: None,
+            frame_kind: Some(aicx::timeline::FrameKind::UserMsg),
+        };
+        let projects = scope.projects();
+        let extraction = if projects.len() > 1 {
+            let projects = projects.to_vec();
+            self.client
+                .extract_intents_for_projects(&config, &projects)?
+        } else {
+            if config.project.is_empty() {
+                config.project = String::new();
+            }
+            self.client.extract_intents(&config)?
+        };
+
+        Ok(extraction
+            .records
+            .into_iter()
+            .take(limit)
+            .map(intent_record_to_loctree)
+            .collect())
+    }
+}
+
+fn intent_record_to_loctree(record: aicx::intents::IntentRecord) -> AicxIntent {
+    AicxIntent {
+        kind: intent_kind_label(record.kind).to_string(),
+        text: record.summary,
+        agent: record.agent,
+        date: record.date,
+        timestamp: record.timestamp,
+        session_id: record.session_id,
+        project: record.project,
+        source_chunk_path: record.source_chunk,
+        frame_kind: Some("user_msg".to_string()),
+        oracle_status: None,
+    }
+}
+
+fn intent_kind_label(kind: aicx::intents::IntentKind) -> &'static str {
+    match kind {
+        aicx::intents::IntentKind::Decision => "decision",
+        aicx::intents::IntentKind::Intent => "intent",
+        aicx::intents::IntentKind::Outcome => "outcome",
+        aicx::intents::IntentKind::Task => "task",
+    }
+}

--- a/loctree-rs/src/aicx/mod.rs
+++ b/loctree-rs/src/aicx/mod.rs
@@ -1,9 +1,10 @@
 //! Read-only consumer wrapper around the external `aicx` memory surfaces.
 //!
 //! Loctree never panics or fails when AICX is missing. By default the wrapper
-//! tries `aicx-mcp --transport stdio` first and falls back to the installed
-//! `aicx` CLI when MCP is unavailable. `LOCT_AICX_MODE=cli|mcp|auto` can force
-//! the transport.
+//! tries the in-process AICX library first when compiled with
+//! `aicx-inprocess`, then falls back to `aicx-mcp --transport stdio`, then the
+//! installed `aicx` CLI. `LOCT_AICX_MODE=inprocess|cli|mcp|auto` can force the
+//! transport.
 //!
 //! Cache: each [`AicxClient`] holds its own per-instance cache, keyed by the
 //! call signature (window/filters/query). The cache is shared across all
@@ -25,6 +26,8 @@
 //!
 //! When neither transport can produce data, the wrapper returns an empty result.
 
+#[cfg(feature = "aicx-inprocess")]
+mod inprocess;
 mod intent_source;
 pub mod intents;
 mod mcp;
@@ -275,6 +278,13 @@ fn truncate_summary(raw: &str) -> String {
 /// healthy even when this returns `false`; callers that need real data should
 /// construct [`AicxClient`] and let it try MCP first.
 pub fn is_aicx_available() -> bool {
+    #[cfg(feature = "aicx-inprocess")]
+    {
+        let mode = AicxMode::from_env();
+        if mode.may_try_inprocess() && inprocess::AicxInProcessClient::from_env().is_ok() {
+            return true;
+        }
+    }
     shell::is_aicx_available()
 }
 
@@ -749,6 +759,8 @@ type SteerCacheKey = (String, SteerFilters);
 pub struct AicxClient {
     scope: ProjectScope,
     mode: AicxMode,
+    #[cfg(feature = "aicx-inprocess")]
+    inprocess: Option<inprocess::AicxInProcessClient>,
     mcp: Option<mcp::AicxMcpClient>,
     /// `true` when the cfg(test) kill switch refused to set up an
     /// AICX transport (see [`test_mode_blocks_spawn`]). Forces
@@ -857,6 +869,7 @@ impl FailureBudget {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AicxMode {
     Auto,
+    InProcess,
     Cli,
     Mcp,
 }
@@ -868,6 +881,7 @@ impl AicxMode {
             .map(|raw| raw.trim().to_ascii_lowercase())
             .as_deref()
         {
+            Some("inprocess") => Self::InProcess,
             Some("cli") => Self::Cli,
             Some("mcp") => Self::Mcp,
             Some("auto") | None | Some("") => Self::Auto,
@@ -878,12 +892,16 @@ impl AicxMode {
         }
     }
 
+    fn may_try_inprocess(self) -> bool {
+        matches!(self, Self::Auto | Self::InProcess)
+    }
+
     fn may_try_mcp(self) -> bool {
-        matches!(self, Self::Auto | Self::Mcp)
+        matches!(self, Self::Auto | Self::InProcess | Self::Mcp)
     }
 
     fn may_fallback_to_cli(self) -> bool {
-        matches!(self, Self::Auto)
+        matches!(self, Self::Auto | Self::InProcess)
     }
 }
 
@@ -951,7 +969,31 @@ impl AicxClient {
         let mut connect_timed_out = false;
 
         let mode = AicxMode::from_env();
-        let mcp = if mode.may_try_mcp() && !test_blocked {
+        #[cfg(feature = "aicx-inprocess")]
+        let inprocess = if mode.may_try_inprocess() && !test_blocked {
+            match inprocess::AicxInProcessClient::from_env() {
+                Ok(client) => Some(client),
+                Err(error) => {
+                    shell::debug_log(format!(
+                        "in-process AICX unavailable; falling back to transports: {error}"
+                    ));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        #[cfg(not(feature = "aicx-inprocess"))]
+        if mode == AicxMode::InProcess {
+            shell::debug_log(
+                "LOCT_AICX_MODE=inprocess requested but loctree was built without aicx-inprocess; falling back to transports",
+            );
+        }
+        #[cfg(feature = "aicx-inprocess")]
+        let should_eager_connect_mcp = mode == AicxMode::Mcp || inprocess.is_none();
+        #[cfg(not(feature = "aicx-inprocess"))]
+        let should_eager_connect_mcp = true;
+        let mcp = if mode.may_try_mcp() && !test_blocked && should_eager_connect_mcp {
             let connect_cap = overlay_deadline.map(|d| d.saturating_duration_since(Instant::now()));
             match mcp::AicxMcpClient::connect_and_check(connect_cap) {
                 Ok(client) => Some(client),
@@ -974,6 +1016,8 @@ impl AicxClient {
         Self {
             scope,
             mode,
+            #[cfg(feature = "aicx-inprocess")]
+            inprocess,
             mcp,
             test_blocked,
             // Three failures within 60 seconds trip the breaker. Generous
@@ -1061,39 +1105,42 @@ impl AicxClient {
             return cached;
         }
 
-        let parsed = match self.mcp_intents(window_hours, limit) {
+        let parsed = match self.inprocess_intents(window_hours, limit) {
             Some(parsed) => parsed,
-            None => {
-                let primary = self.scope.primary();
-                if primary.is_empty() {
-                    // ProjectScope::All — `aicx intents` CLI cannot serve
-                    // "all projects" without a bucket name, and we refuse
-                    // to fabricate one. Operator should configure MCP for
-                    // the all-projects intents path.
-                    shell::debug_log(
-                        "intents: ProjectScope::All has no CLI shape; configure aicx-mcp \
-                         (LOCT_AICX_MODE=auto|mcp) for cross-project intents",
-                    );
-                    return Vec::new();
-                }
-                let limit_str = limit.to_string();
-                let hours_str = window_hours.to_string();
-                let args = [
-                    "intents", "-p", primary, "-H", &hours_str, "--limit", &limit_str, "--emit",
-                    "json",
-                ];
-                let stdout = match self.cli_fallback(&args) {
-                    Some(s) => s,
-                    None => {
-                        // Plan L03 / Finding #8 — do NOT cache failures.
-                        // A transient AICX failure returning None must not
-                        // poison the cache with `Vec::new()` for the
-                        // lifetime of the client. Next call retries.
+            None => match self.mcp_intents(window_hours, limit) {
+                Some(parsed) => parsed,
+                None => {
+                    let primary = self.scope.primary();
+                    if primary.is_empty() {
+                        // ProjectScope::All — `aicx intents` CLI cannot serve
+                        // "all projects" without a bucket name, and we refuse
+                        // to fabricate one. Operator should configure MCP for
+                        // the all-projects intents path.
+                        shell::debug_log(
+                            "intents: ProjectScope::All has no CLI shape; configure in-process AICX or aicx-mcp \
+                         (LOCT_AICX_MODE=auto|inprocess|mcp) for cross-project intents",
+                        );
                         return Vec::new();
                     }
-                };
-                shell::parse_intents(&stdout)
-            }
+                    let limit_str = limit.to_string();
+                    let hours_str = window_hours.to_string();
+                    let args = [
+                        "intents", "-p", primary, "-H", &hours_str, "--limit", &limit_str,
+                        "--emit", "json",
+                    ];
+                    let stdout = match self.cli_fallback(&args) {
+                        Some(s) => s,
+                        None => {
+                            // Plan L03 / Finding #8 — do NOT cache failures.
+                            // A transient AICX failure returning None must not
+                            // poison the cache with `Vec::new()` for the
+                            // lifetime of the client. Next call retries.
+                            return Vec::new();
+                        }
+                    };
+                    shell::parse_intents(&stdout)
+                }
+            },
         };
         cache_put(&self.intents_cache, key, parsed.clone());
         parsed
@@ -1308,6 +1355,54 @@ impl AicxClient {
                 timeout_cap,
             )
         })
+    }
+
+    fn inprocess_intents(&self, window_hours: u64, limit: usize) -> Option<Vec<AicxIntent>> {
+        // Overlay wall-clock budget exhausted — skip the in-process work
+        // before it starts and latch the timeout flag. Once inside the
+        // library call we cannot preempt safely, so the deadline is checked
+        // at the same gate as the external transports.
+        match self.transport_cap() {
+            Ok(_) => {}
+            Err(()) => {
+                self.note_timeout();
+                shell::debug_log("overlay budget exhausted; skipping in-process AICX call");
+                return Some(Vec::new());
+            }
+        }
+
+        if !self.mode.may_try_inprocess() {
+            return None;
+        }
+
+        #[cfg(feature = "aicx-inprocess")]
+        {
+            let Some(client) = &self.inprocess else {
+                return None;
+            };
+            let cap = self
+                .overlay_deadline
+                .map(|deadline| deadline.saturating_duration_since(Instant::now()));
+            match client.intents(&self.scope, window_hours, limit, cap) {
+                Ok(rows) => Some(rows),
+                Err(inprocess::AicxInProcessError::TimedOut) => {
+                    self.note_timeout();
+                    shell::debug_log("in-process AICX call timed out; returning empty result");
+                    Some(Vec::new())
+                }
+                Err(inprocess::AicxInProcessError::Other(error)) => {
+                    shell::debug_log(format!(
+                        "in-process AICX intents unavailable on hot path; returning empty result without subprocess fallback: {error}"
+                    ));
+                    Some(Vec::new())
+                }
+            }
+        }
+        #[cfg(not(feature = "aicx-inprocess"))]
+        {
+            let _ = (window_hours, limit);
+            None
+        }
     }
 
     fn mcp_steer(&self, filters: &SteerFilters) -> Option<Vec<AicxSteerResult>> {
@@ -1630,6 +1725,70 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(aicx_env)]
+    fn mode_selector_accepts_inprocess() {
+        unsafe {
+            clear_aicx_env();
+            std::env::set_var(AICX_MODE_ENV, "inprocess");
+        }
+
+        let mode = AicxMode::from_env();
+
+        unsafe {
+            clear_aicx_env();
+        }
+
+        assert_eq!(mode, AicxMode::InProcess);
+        assert!(mode.may_try_inprocess());
+        assert!(mode.may_try_mcp());
+        assert!(mode.may_fallback_to_cli());
+    }
+
+    #[cfg(feature = "aicx-inprocess")]
+    #[test]
+    #[serial_test::serial(aicx_env)]
+    fn auto_mode_prefers_inprocess_without_eager_mcp_spawn() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mcp_script = dir.path().join("aicx-mcp-mock.sh");
+        let cli_script = dir.path().join("aicx-mock.sh");
+        let log = dir.path().join("spawn.log");
+        write_script(
+            &mcp_script,
+            &format!("#!/bin/sh\nprintf 'mcp\n' >> '{}'\nexit 1\n", log.display()),
+        );
+        write_script(
+            &cli_script,
+            &format!("#!/bin/sh\nprintf 'cli\n' >> '{}'\nexit 1\n", log.display()),
+        );
+        let aicx_home = dir.path().join("aicx-home");
+        std::fs::create_dir_all(aicx_home.join("store")).expect("aicx store dir");
+
+        unsafe {
+            clear_aicx_env();
+            enable_aicx_for_test();
+            std::env::set_var("AICX_HOME", &aicx_home);
+            std::env::set_var(AICX_MODE_ENV, "auto");
+            std::env::set_var(AICX_MCP_BINARY_ENV, &mcp_script);
+            std::env::set_var(AICX_BINARY_ENV, &cli_script);
+        }
+
+        let client = AicxClient::new("Loctree/loctree-suite");
+        let rows = client.intents(168, 100);
+
+        unsafe {
+            clear_aicx_env();
+            std::env::remove_var("AICX_HOME");
+        }
+
+        assert!(rows.is_empty());
+        assert!(!client.transport_timed_out());
+        assert!(
+            !log.exists(),
+            "in-process warm path must not spawn aicx or aicx-mcp"
+        );
+    }
+
+    #[test]
     fn summarize_entry_collapses_raw_unified_diff_json() {
         let raw = r#"{
             "call_id":"call_123",
@@ -1933,6 +2092,7 @@ done
     }
 
     #[cfg(unix)]
+    #[cfg(not(feature = "aicx-inprocess"))]
     #[test]
     #[serial_test::serial(aicx_env)]
     fn auto_mode_falls_back_to_cli_when_mcp_unreachable() {

--- a/loctree-rs/src/aicx/shell.rs
+++ b/loctree-rs/src/aicx/shell.rs
@@ -455,10 +455,10 @@ pub(super) fn parse_steer(stdout: &str) -> Vec<AicxSteerResult> {
         });
 
         // Skip optional blank separator before the next entry.
-        if let Some(peek) = lines.peek() {
-            if peek.trim().is_empty() {
-                lines.next();
-            }
+        if let Some(peek) = lines.peek()
+            && peek.trim().is_empty()
+        {
+            lines.next();
         }
     }
     out
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn parse_steer_handles_three_line_blocks() {
-        let payload = "Loctree/loctree-suite | claude | 2026-04-19 | conversations\n  run_id: -  prompt_id: -  model: -\n  /home/tester/.aicx/store/foo.md\n\nLoctree/loctree-suite | codex | 2026-04-25 | reports\n  run_id: mrbl-001  prompt_id: cut3-task  model: opus-4.7\n  /home/tester/.aicx/store/bar.md\n";
+        let payload = "Loctree/loctree-suite | claude | 2026-04-19 | conversations\n  run_id: -  prompt_id: -  model: -\n  /home/polyversai/.aicx/store/foo.md\n\nLoctree/loctree-suite | codex | 2026-04-25 | reports\n  run_id: mrbl-001  prompt_id: cut3-task  model: opus-4.7\n  /home/polyversai/.aicx/store/bar.md\n";
         let parsed = parse_steer(payload);
         assert_eq!(parsed.len(), 2);
 
@@ -628,7 +628,7 @@ mod tests {
         assert_eq!(parsed[1].model.as_deref(), Some("opus-4.7"));
         assert_eq!(
             parsed[1].source_chunk_path,
-            "/home/tester/.aicx/store/bar.md"
+            "/home/polyversai/.aicx/store/bar.md"
         );
     }
 

--- a/loctree-rs/src/analyzer/c_family_syntax/symbols.rs
+++ b/loctree-rs/src/analyzer/c_family_syntax/symbols.rs
@@ -87,12 +87,12 @@ pub(super) fn extract(content: &str, relative: &str, lang: LanguageId) -> Extrac
         if out.nodes.len() >= MAX_SYMBOLS_PER_FILE {
             break;
         }
-        if let Some((kind, role)) = classify(node, lang) {
-            if let Some((name, name_node)) = resolve_name(node, src, lang, &kind) {
-                push_symbol(
-                    &mut out, relative, lang, kind, role, name, node, name_node, src,
-                );
-            }
+        if let Some((kind, role)) = classify(node, lang)
+            && let Some((name, name_node)) = resolve_name(node, src, lang, &kind)
+        {
+            push_symbol(
+                &mut out, relative, lang, kind, role, name, node, name_node, src,
+            );
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {

--- a/loctree-rs/src/analyzer/cycles.rs
+++ b/loctree-rs/src/analyzer/cycles.rs
@@ -888,12 +888,11 @@ fn find_cycles_normalized(edges: &[(String, String)]) -> Vec<Vec<String>> {
             if scc.len() > 1 {
                 return true;
             }
-            if scc.len() == 1 {
-                if let Some(node) = scc.first() {
-                    if let Some(neighbors) = adj.get(node) {
-                        return neighbors.contains(node);
-                    }
-                }
+            if scc.len() == 1
+                && let Some(node) = scc.first()
+                && let Some(neighbors) = adj.get(node)
+            {
+                return neighbors.contains(node);
             }
             false
         })

--- a/loctree-rs/src/analyzer/dead_parrots/mod.rs
+++ b/loctree-rs/src/analyzer/dead_parrots/mod.rs
@@ -1,6 +1,6 @@
 //! Dead Parrots Module - Janitor tools for code analysis and cleanup
 //!
-//! Named after the Monty Python sketch and the example-app project's "Dead Parrot Protocol"
+//! Named after the Monty Python sketch and the Vista project's "Dead Parrot Protocol"
 //! for identifying unused/dead code that "just resting" but is actually dead.
 //!
 //! This module contains:
@@ -2346,20 +2346,20 @@ mod tests {
 
     #[test]
     fn test_react_lazy_with_subdirectory_resolved_path() {
-        // example-app pattern: lazy(() => import('./features/settings/PasswordResetModal').then(...))
+        // Vista pattern: lazy(() => import('./features/patient/PasswordResetModal').then(...))
         // Component is in a subdirectory, import uses resolved_path via ImportKind::Dynamic
         let mut importer = mock_file("src/App.tsx");
         // Add dynamic import via ImportEntry with resolved_path (like real AST produces)
         let mut dyn_import = ImportEntry::new(
-            "./features/settings/PasswordResetModal".to_string(),
+            "./features/patient/PasswordResetModal".to_string(),
             ImportKind::Dynamic,
         );
-        dyn_import.resolved_path = Some("src/features/settings/PasswordResetModal.tsx".to_string());
+        dyn_import.resolved_path = Some("src/features/patient/PasswordResetModal.tsx".to_string());
         importer.imports.push(dyn_import);
         // Also add to dynamic_imports for backward compat
-        importer.dynamic_imports = vec!["./features/settings/PasswordResetModal".to_string()];
+        importer.dynamic_imports = vec!["./features/patient/PasswordResetModal".to_string()];
 
-        let mut exporter = mock_file("src/features/settings/PasswordResetModal.tsx");
+        let mut exporter = mock_file("src/features/patient/PasswordResetModal.tsx");
         exporter.exports = vec![ExportSymbol {
             name: "PasswordResetModal".to_string(),
             kind: "function".to_string(),
@@ -2385,7 +2385,7 @@ mod tests {
 
     #[test]
     fn test_react_lazy_named_export_via_then_pattern() {
-        // example-app pattern: lazy(() => import('./X').then((m) => ({ default: m.ComponentName })))
+        // Vista pattern: lazy(() => import('./X').then((m) => ({ default: m.ComponentName })))
         // This extracts a NAMED export and re-wraps it as default for React.lazy()
         // The file has NAMED export (not default), but it's still used via dynamic import
         let mut importer = mock_file("src/App.tsx");

--- a/loctree-rs/src/analyzer/env_truth/dockerfile.rs
+++ b/loctree-rs/src/analyzer/env_truth/dockerfile.rs
@@ -91,10 +91,8 @@ fn collapse_continuations(raw: &str) -> Vec<String> {
         out.push(s);
     }
     // Flush any in-progress continuation at end of file.
-    if continuing {
-        if let Some(last) = out.last_mut() {
-            last.push_str(&buf);
-        }
+    if continuing && let Some(last) = out.last_mut() {
+        last.push_str(&buf);
     }
     out
 }

--- a/loctree-rs/src/analyzer/env_truth/gha.rs
+++ b/loctree-rs/src/analyzer/env_truth/gha.rs
@@ -181,7 +181,7 @@ fn walk_strings<F: FnMut(&str)>(value: &Value, f: &mut F) {
 /// not attempt to track `GITHUB_ENV` / `$GITHUB_OUTPUT` propagation across
 /// steps — that is out of scope and architectural.
 ///
-/// W2-c assignment-scope predicate (example-app CI-vars regression): a `$VAR`
+/// W2-c assignment-scope predicate (Vista CI-vars regression): a `$VAR`
 /// reference counts as a read ONLY when no `run:` block in the same workflow
 /// assigns `VAR=` itself and VAR is not a runner-provided builtin
 /// (`GITHUB_*`, `RUNNER_*`, `CI`, ...). `BASE_REF="${1:-main}"` followed by
@@ -213,7 +213,7 @@ pub fn parse_workflow_shell_reads(path: &Path, root: &Path) -> Vec<(String, EnvR
 
     // Pass 1: collect shell-local assignments across every `run:` block in
     // the file (steps share a workflow file even if not a process — file
-    // scope keeps the predicate simple and kills the example-app false positives).
+    // scope keeps the predicate simple and kills the Vista false positives).
     let mut assigned: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for_each_run_block(jobs, &mut |run| {
         let cleaned = strip_gha_expressions(run);
@@ -417,7 +417,7 @@ jobs:
         );
     }
 
-    /// W2-c regression (example-app CI-vars): `BASE_REF` assigned inside the same
+    /// W2-c regression (Vista CI-vars): `BASE_REF` assigned inside the same
     /// workflow's `run:` block must not count as an env read, and runner
     /// builtins (`GITHUB_ENV`, `GITHUB_OUTPUT`, `RUNNER_OS`, `CI`) are
     /// never reads regardless of declarations.

--- a/loctree-rs/src/analyzer/env_truth/mod.rs
+++ b/loctree-rs/src/analyzer/env_truth/mod.rs
@@ -714,7 +714,7 @@ fn render_warning(w: &EnvWarning) -> String {
             sealed_age_days,
             plain_age_days,
         } => format!(
-            "sealed-secret-suspected-stale: `{}` is {}d old vs plain {}d — example-app pattern",
+            "sealed-secret-suspected-stale: `{}` is {}d old vs plain {}d — Vista pattern",
             sealed_path, sealed_age_days, plain_age_days
         ),
         EnvWarning::EncryptedDecodeBlocked { source } => {

--- a/loctree-rs/src/analyzer/env_truth/types.rs
+++ b/loctree-rs/src/analyzer/env_truth/types.rs
@@ -205,7 +205,7 @@ pub struct OrphanRead {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EnvWarning {
     /// A higher-precedence declaration is materially older than a
-    /// lower-precedence one. The classic example-app incident: stale SealedSecret
+    /// lower-precedence one. The classic Vista incident: stale SealedSecret
     /// (highest precedence, slow update cadence) overrides a freshly-edited
     /// `.env` / ConfigMap.
     StaleOverridesFresh {
@@ -228,7 +228,7 @@ pub enum EnvWarning {
     OrphanDeclaration { sources: Vec<String> },
     /// Specialization of `StaleOverridesFresh` for the SealedSecret/plain
     /// pair — emitted as a separate kind so CI gates can target the
-    /// example-app-style failure surface specifically.
+    /// Vista-style failure surface specifically.
     SealedSecretSuspectedStale {
         sealed_path: String,
         sealed_age_days: u32,

--- a/loctree-rs/src/analyzer/env_truth/warnings.rs
+++ b/loctree-rs/src/analyzer/env_truth/warnings.rs
@@ -81,43 +81,43 @@ pub fn compute_warnings(
     //    so `decl.sources[0]` wins at deploy time. The runner-up gives the
     //    canonical "obvious neighbor" comparison, but the SealedSecret/
     //    SOPS/ExternalSecret specialization scans **all** lower-rank
-    //    plain-bearing sources — example-app's case had a stale SealedSecret
+    //    plain-bearing sources — Vista's case had a stale SealedSecret
     //    overriding a fresh ConfigMap several layers down, not just the
     //    immediate runner-up.
     if decl.sources.len() >= 2 {
         let high = &decl.sources[0];
         let low = &decl.sources[1];
-        if let (Some(h_age), Some(l_age)) = (high.mtime_age_days, low.mtime_age_days) {
-            if h_age > l_age && h_age.saturating_sub(l_age) >= stale_threshold_days {
-                let delta = h_age.saturating_sub(l_age);
-                decl.precedence_warnings
-                    .push(EnvWarning::StaleOverridesFresh {
-                        stale_source: high.path.clone(),
-                        fresh_source: low.path.clone(),
-                        age_delta_days: delta,
-                    });
-            }
+        if let (Some(h_age), Some(l_age)) = (high.mtime_age_days, low.mtime_age_days)
+            && h_age > l_age
+            && h_age.saturating_sub(l_age) >= stale_threshold_days
+        {
+            let delta = h_age.saturating_sub(l_age);
+            decl.precedence_warnings
+                .push(EnvWarning::StaleOverridesFresh {
+                    stale_source: high.path.clone(),
+                    fresh_source: low.path.clone(),
+                    age_delta_days: delta,
+                });
         }
-        // example-app specialization: highest is sealed/sops/external AND any
+        // Vista specialization: highest is sealed/sops/external AND any
         // lower-rank plain-bearing source is materially fresher.
         if matches!(
             high.kind,
             EnvSourceKind::SealedSecret | EnvSourceKind::SopsFile | EnvSourceKind::ExternalSecret
-        ) {
-            if let Some(h_age) = high.mtime_age_days {
-                let plain_fresh_neighbor = decl.sources[1..].iter().find(|s| {
-                    matches!(s.value_present, ValuePresence::Plain { .. })
-                        && s.mtime_age_days
-                            .is_some_and(|a| h_age > a && h_age - a >= stale_threshold_days)
-                });
-                if let Some(neighbor) = plain_fresh_neighbor {
-                    decl.precedence_warnings
-                        .push(EnvWarning::SealedSecretSuspectedStale {
-                            sealed_path: high.path.clone(),
-                            sealed_age_days: h_age,
-                            plain_age_days: neighbor.mtime_age_days.unwrap_or(0),
-                        });
-                }
+        ) && let Some(h_age) = high.mtime_age_days
+        {
+            let plain_fresh_neighbor = decl.sources[1..].iter().find(|s| {
+                matches!(s.value_present, ValuePresence::Plain { .. })
+                    && s.mtime_age_days
+                        .is_some_and(|a| h_age > a && h_age - a >= stale_threshold_days)
+            });
+            if let Some(neighbor) = plain_fresh_neighbor {
+                decl.precedence_warnings
+                    .push(EnvWarning::SealedSecretSuspectedStale {
+                        sealed_path: high.path.clone(),
+                        sealed_age_days: h_age,
+                        plain_age_days: neighbor.mtime_age_days.unwrap_or(0),
+                    });
             }
         }
     }

--- a/loctree-rs/src/analyzer/for_ai.rs
+++ b/loctree-rs/src/analyzer/for_ai.rs
@@ -172,10 +172,11 @@ fn location_path(location: &str) -> Option<&str> {
     if location.is_empty() || location == "unknown" {
         return None;
     }
-    if let Some((path, line)) = location.rsplit_once(':') {
-        if !path.is_empty() && line.chars().all(|c| c.is_ascii_digit()) {
-            return Some(path);
-        }
+    if let Some((path, line)) = location.rsplit_once(':')
+        && !path.is_empty()
+        && line.chars().all(|c| c.is_ascii_digit())
+    {
+        return Some(path);
     }
     Some(location)
 }

--- a/loctree-rs/src/analyzer/html.rs
+++ b/loctree-rs/src/analyzer/html.rs
@@ -283,7 +283,7 @@ mod tests {
 
         // Verify key parts exist in the Leptos-rendered output
         assert!(html.contains("<!DOCTYPE html>"));
-        assert!(html.contains("Loctree Report")); // Title in new example-app design
+        assert!(html.contains("Loctree Report")); // Title in new Vista design
 
         // The output format might differ slightly from legacy, check for content
         assert!(html.contains("Hint"));

--- a/loctree-rs/src/analyzer/occurrences.rs
+++ b/loctree-rs/src/analyzer/occurrences.rs
@@ -9,12 +9,13 @@
 //! — there are no fuzzy suggestions promoted as primary results, because a
 //! suggestion is not evidence.
 //!
-//! The codescribe `utterance_id` failure class is the canonical motivation: a
+//! The CodeScribe `utterance_id` failure class is the canonical motivation: a
 //! `let mut utterance_id` plus later `utterance_id += 1` increments living
 //! inside a 400-line function were invisible to `find`/`tagmap`. The literal
 //! scanner sees them because it does not depend on symbol extraction.
 
 use serde::{Deserialize, Serialize};
+use strsim::levenshtein;
 
 use crate::snapshot::Snapshot;
 use crate::types::{FileAnalysis, ImportEntry, ReexportKind};
@@ -258,6 +259,23 @@ pub struct SuggestedNext {
     pub reason: String,
 }
 
+/// Symbol-table hint surfaced only when literal occurrences are absent.
+///
+/// These are prefix/substring/fuzzy matches against known symbols, not evidence
+/// that the queried identifier exists. Keeping them on a separate field
+/// preserves the core literal contract while giving agents an immediate
+/// typo/rename lead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NearMatch {
+    pub symbol: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    pub kind: String,
+    pub match_kind: &'static str,
+    pub source: &'static str,
+}
+
 /// Definition-vs-callsite roll-up over the whole result set.
 ///
 /// Agents asking "is this symbol mostly *defined* here or mostly *used* here?"
@@ -486,6 +504,11 @@ pub struct OccurrenceResults {
     /// Next structural commands an agent can run after reading this literal
     /// result. These remain suggestions, not evidence.
     pub suggested_next: Vec<SuggestedNext>,
+    /// Prefix/substring symbol-table hints when the literal result set is empty.
+    /// These are never primary matches and are omitted when exact occurrences
+    /// exist or no nearby symbol names are known.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub near_matches: Vec<NearMatch>,
     /// Definition-vs-callsite roll-up for the whole result set. `Some` whenever
     /// there is at least one hit; omitted on a not-found result. Additive.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -506,9 +529,9 @@ fn is_false(b: &bool) -> bool {
 ///
 /// Default (`whole_token = false`) preserves the historical behavior exactly:
 /// `[A-Za-z0-9_]` are identifier-internal, so `backdrop` still matches inside
-/// the hyphenated CSS token `--sample-z-overlay-backdrop`. Opt-in
+/// the hyphenated CSS token `--vista-z-overlay-backdrop`. Opt-in
 /// `whole_token = true` additionally treats `-` as token-internal, so the same
-/// query no longer lights up `overlay-backdrop` / `--sample-z-overlay-backdrop`
+/// query no longer lights up `overlay-backdrop` / `--vista-z-overlay-backdrop`
 /// — the z-index noise the literal layer used to drag in.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ScanOptions {
@@ -566,7 +589,7 @@ fn is_ident_char(c: char) -> bool {
 
 /// Boundary test under a given [`ScanOptions`]. With `whole_token`, `-` also
 /// counts as token-internal, so a query like `backdrop` no longer matches
-/// inside `overlay-backdrop` / `--sample-z-overlay-backdrop`.
+/// inside `overlay-backdrop` / `--vista-z-overlay-backdrop`.
 #[inline]
 fn is_boundary_char(c: char, whole_token: bool) -> bool {
     is_ident_char(c) || (whole_token && c == '-')
@@ -1424,6 +1447,7 @@ where
         }),
         scope_classifications,
         suggested_next,
+        near_matches: Vec::new(),
         role_summary: role,
         file_context: Vec::new(),
     }
@@ -1545,6 +1569,7 @@ where
         }),
         scope_classifications,
         suggested_next,
+        near_matches: Vec::new(),
         role_summary: role,
         file_context: Vec::new(),
     }
@@ -1565,6 +1590,114 @@ pub fn enrich_with_snapshot(results: &mut OccurrenceResults, snapshot: &Snapshot
     }
     results.file_context = file_contexts(snapshot, &results.occurrences);
     results.suggested_next = suggested_next(&results.query, &results.occurrences);
+}
+
+pub fn attach_near_matches(results: &mut OccurrenceResults, analyses: &[FileAnalysis]) {
+    if results.total == 0 {
+        results.near_matches = near_symbol_matches(&results.query, analyses);
+    }
+}
+
+const MAX_NEAR_MATCHES: usize = 8;
+
+pub fn near_symbol_matches(query: &str, analyses: &[FileAnalysis]) -> Vec<NearMatch> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let query_lower = query.to_ascii_lowercase();
+    let mut matches = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+
+    for analysis in analyses {
+        for export in &analysis.exports {
+            push_near_match(
+                &mut matches,
+                &mut seen,
+                &query_lower,
+                &export.name,
+                &analysis.path,
+                export.line,
+                &export.kind,
+            );
+        }
+        for local in &analysis.local_symbols {
+            push_near_match(
+                &mut matches,
+                &mut seen,
+                &query_lower,
+                &local.name,
+                &analysis.path,
+                local.line,
+                &local.kind,
+            );
+        }
+    }
+
+    matches.sort_by(|a, b| {
+        match_rank(a.match_kind)
+            .cmp(&match_rank(b.match_kind))
+            .then(a.symbol.len().cmp(&b.symbol.len()))
+            .then(a.symbol.cmp(&b.symbol))
+            .then(a.file.cmp(&b.file))
+            .then(a.line.cmp(&b.line))
+    });
+    matches.truncate(MAX_NEAR_MATCHES);
+    matches
+}
+
+fn push_near_match(
+    matches: &mut Vec<NearMatch>,
+    seen: &mut std::collections::BTreeSet<(String, String, Option<usize>, String)>,
+    query_lower: &str,
+    symbol: &str,
+    file: &str,
+    line: Option<usize>,
+    kind: &str,
+) {
+    let symbol_lower = symbol.to_ascii_lowercase();
+    if symbol_lower == query_lower {
+        return;
+    }
+    let match_kind = if symbol_lower.starts_with(query_lower) {
+        "prefix"
+    } else if symbol_lower.contains(query_lower) {
+        "substring"
+    } else if is_fuzzy_near_match(query_lower, &symbol_lower) {
+        "fuzzy"
+    } else {
+        return;
+    };
+    let key = (symbol.to_string(), file.to_string(), line, kind.to_string());
+    if !seen.insert(key) {
+        return;
+    }
+    matches.push(NearMatch {
+        symbol: symbol.to_string(),
+        file: file.to_string(),
+        line,
+        kind: kind.to_string(),
+        match_kind,
+        source: "symbol_table",
+    });
+}
+
+fn match_rank(kind: &str) -> u8 {
+    match kind {
+        "prefix" => 0,
+        "substring" => 1,
+        "fuzzy" => 2,
+        _ => 3,
+    }
+}
+
+fn is_fuzzy_near_match(query_lower: &str, symbol_lower: &str) -> bool {
+    if query_lower.len() < 4 {
+        return false;
+    }
+    let distance = levenshtein(query_lower, symbol_lower);
+    let max_distance = if query_lower.len() >= 12 { 3 } else { 2 };
+    distance > 0 && distance <= max_distance
 }
 
 /// Maximum number of hit-carrying files we attach importer/consumer context for.
@@ -1866,10 +1999,10 @@ fn reexport_anchor(snapshot: &Snapshot, target_path: &str, query: &str) -> Optio
                     .as_deref()
                     .and_then(|path| snapshot_path_for(snapshot, path))
                     .or_else(|| rust_source_target_path(snapshot, &file.path, &reexport.source));
-                if let Some(source_path) = source_path {
-                    if let Some(anchor) = export_anchor(snapshot, &source_path, query) {
-                        return Some(anchor);
-                    }
+                if let Some(source_path) = source_path
+                    && let Some(anchor) = export_anchor(snapshot, &source_path, query)
+                {
+                    return Some(anchor);
                 }
             }
             ReexportKind::Named(names) => {
@@ -1891,10 +2024,10 @@ fn reexport_anchor(snapshot: &Snapshot, target_path: &str, query: &str) -> Optio
                             original,
                         )
                     });
-                if let Some(source_path) = source_path {
-                    if let Some(anchor) = export_anchor(snapshot, &source_path, original) {
-                        return Some(anchor);
-                    }
+                if let Some(source_path) = source_path
+                    && let Some(anchor) = export_anchor(snapshot, &source_path, original)
+                {
+                    return Some(anchor);
                 }
             }
         }
@@ -2743,7 +2876,7 @@ mod tests {
 
     #[test]
     fn whole_token_excludes_hyphenated_neighbors() {
-        let line = "  z-index: var(--sample-z-overlay-backdrop);";
+        let line = "  z-index: var(--vista-z-overlay-backdrop);";
         // Default boundary: `backdrop` leaks into the hyphenated custom property.
         assert_eq!(occurrences_in_line_with(line, "backdrop", false).len(), 1);
         // whole_token: hyphen is token-internal, so the noisy hit disappears.
@@ -2758,7 +2891,7 @@ mod tests {
 
     #[test]
     fn scan_files_with_whole_token_drops_z_index_noise() {
-        let css = ".backdrop {}\n  --sample-z-overlay-backdrop: 40;";
+        let css = ".backdrop {}\n  --vista-z-overlay-backdrop: 40;";
         let loose = scan_files_with([("a.css", css)], "backdrop", ScanOptions::default());
         let tight = scan_files_with(
             [("a.css", css)],

--- a/loctree-rs/src/analyzer/pipelines.rs
+++ b/loctree-rs/src/analyzer/pipelines.rs
@@ -590,9 +590,9 @@ mod tests {
         // FE file with matching emit/listen
         let mut fe = FileAnalysis::new("src/frontend.ts".into());
         fe.event_emits
-            .push(mk_event("sample://ok", 10, "emit_literal", false));
+            .push(mk_event("vista://ok", 10, "emit_literal", false));
         fe.event_listens
-            .push(mk_event("sample://ok", 5, "listen_literal", true));
+            .push(mk_event("vista://ok", 5, "listen_literal", true));
         fe.command_calls.push(CommandRef {
             name: "unified_ai_chat".into(),
             exposed_name: None,
@@ -605,7 +605,7 @@ mod tests {
         // BE file emitting ghost event and handling command
         let mut be = FileAnalysis::new("src/backend.rs".into());
         be.event_emits
-            .push(mk_event("sample://ghost", 20, "emit_literal", false));
+            .push(mk_event("vista://ghost", 20, "emit_literal", false));
         be.command_handlers.push(CommandRef {
             name: "unified_ai_chat".into(),
             exposed_name: None,
@@ -626,7 +626,7 @@ mod tests {
             plugin_name: None,
         });
         racy.event_listens
-            .push(mk_event("sample://racy", 10, "listen_literal", false));
+            .push(mk_event("vista://racy", 10, "listen_literal", false));
 
         let analyses = vec![fe, be, racy];
         let summary = build_pipeline_summary(
@@ -645,12 +645,12 @@ mod tests {
         let ghost = events["ghostEmits"]
             .as_array()
             .expect("ghostEmits array present");
-        assert!(ghost.iter().any(|g| g["name"] == "sample://ghost"));
+        assert!(ghost.iter().any(|g| g["name"] == "vista://ghost"));
 
         let orphans = events["orphanListeners"]
             .as_array()
             .expect("orphanListeners array present");
-        assert!(orphans.iter().any(|o| o["name"] == "sample://racy"));
+        assert!(orphans.iter().any(|o| o["name"] == "vista://racy"));
 
         let chains = summary["commands"]["chains"]
             .as_array()

--- a/loctree-rs/src/analyzer/resolvers.rs
+++ b/loctree-rs/src/analyzer/resolvers.rs
@@ -294,8 +294,7 @@ impl TsPathResolver {
         let rest = if let Some(r) = normalized.strip_prefix("$app/") {
             format!("app/{}", r)
         } else {
-            let r = normalized.strip_prefix("$env/")?;
-            format!("env/{}", r)
+            format!("env/{}", normalized.strip_prefix("$env/")?)
         };
 
         // Try monorepo layout: packages/kit/src/runtime/{app|env}/...
@@ -325,8 +324,7 @@ impl TsPathResolver {
         let rest = if let Some(r) = normalized.strip_prefix("$app/") {
             format!("app/{}", r)
         } else {
-            let r = normalized.strip_prefix("$env/")?;
-            format!("env/{}", r)
+            format!("env/{}", normalized.strip_prefix("$env/")?)
         };
 
         // Try node_modules layout

--- a/loctree-rs/src/analyzer/scan.rs
+++ b/loctree-rs/src/analyzer/scan.rs
@@ -467,10 +467,14 @@ pub(crate) fn analyze_file(path: &Path, ctx: &AnalyzeContext) -> io::Result<File
         None
     };
     let dispatch_ext = shebang_ext.unwrap_or(ext.as_str());
+    let is_plain_extensionless_text =
+        ext.is_empty() && !is_makefile && !is_loctree_config && shebang_ext.is_none();
 
     let mut analysis = if is_loctree_config {
         FileAnalysis::new(relative.clone())
-    } else if is_scan_only_resource_extension(dispatch_ext) && resource_kind(&relative).is_some() {
+    } else if is_plain_extensionless_text
+        || (is_scan_only_resource_extension(dispatch_ext) && resource_kind(&relative).is_some())
+    {
         FileAnalysis::new(relative)
     } else if is_makefile || dispatch_ext == "mk" || dispatch_ext == "make" {
         analyze_makefile(&content, relative)

--- a/loctree-rs/src/analyzer/swift.rs
+++ b/loctree-rs/src/analyzer/swift.rs
@@ -252,20 +252,20 @@ fn parse_imports(content: &str) -> Vec<ImportEntry> {
     let mut imports: Vec<ImportEntry> = Vec::new();
     for (idx, line) in content.lines().enumerate() {
         let effective = strip_line_comment(line);
-        if let Some(caps) = RE_IMPORT.captures(effective) {
-            if let Some(m) = caps.get(1) {
-                let path = m.as_str().trim();
-                if path.is_empty() {
-                    continue;
-                }
-                if imports.iter().any(|i| i.source == path) {
-                    continue;
-                }
-                let mut entry = ImportEntry::new(path.to_string(), ImportKind::Static);
-                entry.line = Some(idx + 1);
-                entry.resolution = ImportResolutionKind::Unknown;
-                imports.push(entry);
+        if let Some(caps) = RE_IMPORT.captures(effective)
+            && let Some(m) = caps.get(1)
+        {
+            let path = m.as_str().trim();
+            if path.is_empty() {
+                continue;
             }
+            if imports.iter().any(|i| i.source == path) {
+                continue;
+            }
+            let mut entry = ImportEntry::new(path.to_string(), ImportKind::Static);
+            entry.line = Some(idx + 1);
+            entry.resolution = ImportResolutionKind::Unknown;
+            imports.push(entry);
         }
     }
     imports

--- a/loctree-rs/src/analyzer/twins.rs
+++ b/loctree-rs/src/analyzer/twins.rs
@@ -661,10 +661,10 @@ pub fn categorize_twin(twin: &ExactTwin) -> TwinCategory {
         return TwinCategory::Namesake;
     }
 
-    if let Some(sim) = twin.signature_similarity {
-        if sim == 0.0 {
-            return TwinCategory::Namesake;
-        }
+    if let Some(sim) = twin.signature_similarity
+        && sim == 0.0
+    {
+        return TwinCategory::Namesake;
     }
 
     TwinCategory::SameLanguage(languages.into_iter().next().unwrap_or(Language::Other))
@@ -1157,17 +1157,17 @@ pub fn detect_exact_twins_with_frameworks(
         // Class B: Token from a comment block flagged as a type declaration.
         let mut is_comment = false;
         for loc in &locations {
-            if let Ok(content) = std::fs::read_to_string(&loc.file_path) {
-                if let Some(line) = content.lines().nth(loc.line.saturating_sub(1)) {
-                    let trimmed = line.trim();
-                    if trimmed.starts_with("//")
-                        || trimmed.starts_with("/*")
-                        || trimmed.starts_with("*")
-                        || trimmed.starts_with("#")
-                    {
-                        is_comment = true;
-                        break;
-                    }
+            if let Ok(content) = std::fs::read_to_string(&loc.file_path)
+                && let Some(line) = content.lines().nth(loc.line.saturating_sub(1))
+            {
+                let trimmed = line.trim();
+                if trimmed.starts_with("//")
+                    || trimmed.starts_with("/*")
+                    || trimmed.starts_with("*")
+                    || trimmed.starts_with("#")
+                {
+                    is_comment = true;
+                    break;
                 }
             }
         }

--- a/loctree-rs/src/cli/command/help_texts.rs
+++ b/loctree-rs/src/cli/command/help_texts.rs
@@ -1292,7 +1292,7 @@ DESCRIPTION:
     Deps:       External files imported by core (outside the directory)
     Consumers:  Files outside the directory that import core files
 
-    Perfect for understanding feature modules like 'src/features/settings/'.
+    Perfect for understanding feature modules like 'src/features/patients/'.
 
 OPTIONS:
     --consumers, -c    Include files that import from this directory (default)
@@ -1306,17 +1306,17 @@ ARGUMENTS:
     <DIRECTORY>        Path to the directory to analyze (required)
 
 EXAMPLES:
-    loct focus src/features/settings/           # Focus + deps + consumers
+    loct focus src/features/patients/           # Focus + deps + consumers
     loct focus src/components/ --no-consumers   # Dependency-only view
     loct focus lib/utils/ --depth 1             # Limit external dep depth
     loct focus src/api/ --json                  # JSON output for AI tools
 
 OUTPUT FORMAT:
-    Focus: src/features/settings/
+    Focus: src/features/patients/
 
     Core (12 files, 2,340 LOC):
-      src/features/settings/index.ts
-      src/features/settings/SettingsList.tsx
+      src/features/patients/index.ts
+      src/features/patients/PatientsList.tsx
       ...
 
     Internal edges: 18 imports within directory
@@ -1495,7 +1495,7 @@ OUTPUT FORMAT:
       ...
 
     Orphan Files (0 importers, 2):
-      src/features/settings/SettingsList.tsx (504 LOC)
+      src/features/patients/PatientsList.tsx (504 LOC)
       src/components/deprecated/OldButton.tsx (89 LOC)
 
     Shadow Exports (1):
@@ -1811,7 +1811,7 @@ OPTIONS:
     --help, -h                   Show this help message
 
 FAIL-ON KINDS:
-    stale-sealed-overrides-fresh-plain   The example-app pattern: stale SealedSecret/
+    stale-sealed-overrides-fresh-plain   The Vista pattern: stale SealedSecret/
                                          SOPS overrides a fresh dotenv/configmap.
     stale-overrides-fresh                Generic: highest-precedence is older
                                          than runner-up by stale-threshold-days.

--- a/loctree-rs/src/cli/command/options.rs
+++ b/loctree-rs/src/cli/command/options.rs
@@ -236,7 +236,7 @@ pub struct FindOptions {
     pub offset: usize,
 
     /// Literal-mode: treat `-` as token-internal so `backdrop` does not match
-    /// inside `overlay-backdrop` / `--sample-z-overlay-backdrop`. Opt-in; the
+    /// inside `overlay-backdrop` / `--vista-z-overlay-backdrop`. Opt-in; the
     /// default boundary is unchanged. Ignored outside `--literal`.
     pub whole_token: bool,
 
@@ -265,7 +265,7 @@ pub struct OccurrencesOptions {
     pub roots: Vec<PathBuf>,
 
     /// Treat `-` as token-internal (tighter boundary) so `backdrop` does not
-    /// match inside `overlay-backdrop` / `--sample-z-overlay-backdrop`. Opt-in;
+    /// match inside `overlay-backdrop` / `--vista-z-overlay-backdrop`. Opt-in;
     /// the default boundary is unchanged.
     pub whole_token: bool,
 
@@ -274,6 +274,9 @@ pub struct OccurrencesOptions {
 
     /// Suppress the full occurrence list, keep only counters (`slim`).
     pub count_only: bool,
+
+    /// Emit terse human output: `path:line context` per occurrence.
+    pub compact: bool,
 
     /// Zero-based occurrence offset for paged output.
     pub offset: usize,

--- a/loctree-rs/src/cli/dispatch/handlers/analysis.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/analysis.rs
@@ -1556,7 +1556,7 @@ pub fn handle_focus_command(opts: &FocusOptions, global: &GlobalOptions) -> Disp
         Some(f) => f,
         None => {
             // Distinguish a genuine wrong path from a correct path that is simply
-            // parked outside the snapshot by .loctignore (loctree-feedback.md: example-app
+            // parked outside the snapshot by .loctignore (loctree-feedback.md: vista
             // docs/). When the latter, lead with the precise cause instead of
             // telling the user to "check the path".
             let ignore_hint = crate::fs_utils::loctignore_exclusion_hint(root, &opts.target);

--- a/loctree-rs/src/cli/dispatch/handlers/context/atlas.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/context/atlas.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::context_render::current_iso_timestamp;
-use crate::pack::ContextPack;
+use crate::pack::{ContextPack, RiskCacheScope};
 
 pub const CONTEXT_ATLAS_PROTOCOL: &str = "loctree.context_atlas.v1";
 pub const CONTEXT_ATLAS_DIR: &str = "context-atlas";
@@ -327,13 +327,18 @@ struct CardOverflow {
 }
 
 fn snapshot_label(pack: &ContextPack) -> String {
+    if snapshot_missing(pack) {
+        return "no snapshot".to_string();
+    }
     let branch = pack.project.branch.as_deref().unwrap_or("unknown");
     let commit = pack.project.commit.as_deref().unwrap_or("unknown");
     format!("{}@{}", branch, commit)
 }
 
 fn atlas_freshness_line(pack: &ContextPack) -> String {
-    if pack.risk.stale_snapshot {
+    if snapshot_missing(pack) {
+        "NO SNAPSHOT - run loct scan before relying on this card.".to_string()
+    } else if pack.risk.stale_snapshot {
         format!(
             "STALE - card snapshot {} lags live git state; refresh with `loct context --full` before relying on this card.",
             snapshot_label(pack)
@@ -344,6 +349,11 @@ fn atlas_freshness_line(pack: &ContextPack) -> String {
     } else {
         "fresh - card matches the loaded snapshot authority.".to_string()
     }
+}
+
+fn snapshot_missing(pack: &ContextPack) -> bool {
+    matches!(pack.risk.cache_scope, RiskCacheScope::MissingSnapshot)
+        || pack.risk.snapshot_health.as_deref() == Some("missing_snapshot")
 }
 
 fn render_manifest(manifest: &ContextAtlasManifest) -> String {
@@ -523,7 +533,9 @@ fn line_count(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pack::{AuthorityLabel, ProjectIdentity, StructuralFile, StructuralRole};
+    use crate::pack::{
+        AuthorityLabel, ProjectIdentity, RiskCacheScope, StructuralFile, StructuralRole,
+    };
     use tempfile::TempDir;
 
     #[test]
@@ -701,6 +713,42 @@ mod tests {
         assert!(
             body.content
                 .contains("refresh with `loct context --full` before relying on this card")
+        );
+    }
+
+    #[test]
+    fn render_json_card_surfaces_missing_snapshot_in_header() {
+        let mut pack = ContextPack::empty(ProjectIdentity {
+            canonical_root: Some("/tmp/proj".to_string()),
+            branch: Some("main".to_string()),
+            commit: Some("abc1234".to_string()),
+            snapshot_id: None,
+        });
+        pack.risk.cache_scope = RiskCacheScope::MissingSnapshot;
+        pack.risk.cache_scope_authority = AuthorityLabel::RepoVerified;
+        pack.risk.snapshot_health = Some("missing_snapshot".to_string());
+
+        let body = render_json_card(
+            &pack,
+            "00-core-map.md",
+            "Core Map",
+            "lead",
+            "missing",
+            json!({}),
+        );
+
+        assert!(
+            body.content
+                .contains("Freshness: `NO SNAPSHOT - run loct scan"),
+            "missing atlas cards must carry a no-snapshot header: {}",
+            body.content
+        );
+        assert!(
+            !body
+                .content
+                .contains("Freshness: `fresh - card matches the loaded snapshot authority.`"),
+            "missing snapshot must not render as fresh: {}",
+            body.content
         );
     }
 

--- a/loctree-rs/src/cli/dispatch/handlers/context/pill.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/context/pill.rs
@@ -16,8 +16,8 @@ use std::time::Instant;
 use crate::aicx::summarize_entry;
 use crate::context_render::chunk_ref;
 use crate::pack::{
-    AuthorityLabel, AuthoritySlice, ContextPack, MemoryEntry, MemorySlice, RiskSlice,
-    RuntimeIdiomTag, RuntimeSlice,
+    AuthorityLabel, AuthoritySlice, ContextPack, MemoryEntry, MemorySlice, RiskCacheScope,
+    RiskSlice, RuntimeIdiomTag, RuntimeSlice,
 };
 
 use super::budget::{Budget, count_lines, rank_and_render, truncate_with_tail};
@@ -153,25 +153,24 @@ fn render_header(input: &PillInput<'_>) -> String {
         branch = branch,
         ts = input.timestamp_iso,
     ));
-    let snapshot_state = if input.pack.risk.stale_snapshot {
-        "stale"
-    } else {
-        "fresh"
-    };
     // `AutoScope::dirty` is the canonical worktree-dirty signal captured at
     // scope discovery. Fall back to the risk slice if discovery never ran.
     let dirty = input.scope.dirty || input.pack.risk.dirty_worktree;
-    header.push_str(&format!(
-        "_{files} files · {edges} import edges · snapshot {state} · {worktree}_\n\n",
-        files = input.snapshot_files,
-        edges = input.snapshot_edges,
-        state = snapshot_state,
-        worktree = if dirty {
-            "dirty worktree"
-        } else {
-            "clean worktree"
-        },
-    ));
+    let worktree = if dirty {
+        "dirty worktree"
+    } else {
+        "clean worktree"
+    };
+    if snapshot_is_missing(input) {
+        header.push_str(&format!("_no snapshot - run `loct scan` · {worktree}_\n\n"));
+    } else {
+        header.push_str(&format!(
+            "_{files} files · {edges} import edges · snapshot {state} · {worktree}_\n\n",
+            files = input.snapshot_files,
+            edges = input.snapshot_edges,
+            state = snapshot_state_label(input),
+        ));
+    }
     header
 }
 
@@ -185,25 +184,27 @@ fn render_tldr(input: &PillInput<'_>, m: &Metrics) -> Section {
     lines.push(String::new());
 
     // What this is (auto-derived from project name + scope branch hint)
-    let what = match input.scope.branch_hint.as_deref() {
-        Some(hint) if !hint.is_empty() => format!(
-            "**What this is.** `{}` repository — current focus: _{}_.",
-            input.project_name, hint
-        ),
-        _ => format!(
-            "**What this is.** `{}` repository ({} files, {} import edges).",
-            input.project_name, input.snapshot_files, input.snapshot_edges
-        ),
+    let what = if snapshot_is_missing(input) {
+        format!(
+            "**What this is.** `{}` repository — no snapshot. Run `loct scan` before trusting file/import metrics.",
+            input.project_name
+        )
+    } else {
+        match input.scope.branch_hint.as_deref() {
+            Some(hint) if !hint.is_empty() => format!(
+                "**What this is.** `{}` repository — current focus: _{}_.",
+                input.project_name, hint
+            ),
+            _ => format!(
+                "**What this is.** `{}` repository ({} files, {} import edges).",
+                input.project_name, input.snapshot_files, input.snapshot_edges
+            ),
+        }
     };
     lines.push(what);
     lines.push(String::new());
 
     // Where you stand
-    let snapshot_state = if input.pack.risk.stale_snapshot {
-        "stale"
-    } else {
-        "fresh"
-    };
     let worktree = if input.pack.risk.dirty_worktree {
         "dirty"
     } else {
@@ -211,7 +212,8 @@ fn render_tldr(input: &PillInput<'_>, m: &Metrics) -> Section {
     };
     let branch = input.scope.branch.as_deref().unwrap_or("<detached>");
     lines.push(format!(
-        "**Where you stand.** Branch `{branch}`, {worktree} worktree, snapshot {snapshot_state}."
+        "**Where you stand.** Branch `{branch}`, {worktree} worktree, snapshot {}.",
+        snapshot_state_label(input)
     ));
     if !input.scope.commit_hints.is_empty() {
         lines.push(format!(
@@ -270,16 +272,23 @@ fn render_tldr(input: &PillInput<'_>, m: &Metrics) -> Section {
     lines.push(String::new());
 
     // Snapshot facts (compact one-liner sourced from collected metrics)
-    lines.push(format!(
-        "**Snapshot facts.** {hubs} hubs · {idiom} idiom tag(s) · {dispatch} dispatch edge(s) · {env} env contract(s) · {mem} memory entr{plural} · {auth} authority claim(s).",
-        hubs = m.hub_count,
-        idiom = m.idiom_tag_count,
-        dispatch = m.dispatch_edge_count,
-        env = m.env_contract_count,
-        mem = m.memory_entry_count,
-        plural = if m.memory_entry_count == 1 { "y" } else { "ies" },
-        auth = m.authority_total,
-    ));
+    if snapshot_is_missing(input) {
+        lines.push(
+            "**Snapshot facts.** no snapshot - run `loct scan`; derived file/import metrics are unavailable. (RepoVerified)"
+                .to_string(),
+        );
+    } else {
+        lines.push(format!(
+            "**Snapshot facts.** {hubs} hubs · {idiom} idiom tag(s) · {dispatch} dispatch edge(s) · {env} env contract(s) · {mem} memory entr{plural} · {auth} authority claim(s).",
+            hubs = m.hub_count,
+            idiom = m.idiom_tag_count,
+            dispatch = m.dispatch_edge_count,
+            env = m.env_contract_count,
+            mem = m.memory_entry_count,
+            plural = if m.memory_entry_count == 1 { "y" } else { "ies" },
+            auth = m.authority_total,
+        ));
+    }
     lines.push(String::new());
 
     // What's stale
@@ -341,7 +350,9 @@ fn top_three_warnings(input: &PillInput<'_>, m: &Metrics) -> Vec<String> {
         );
     }
 
-    let risk_message = if input.pack.risk.stale_snapshot {
+    let risk_message = if snapshot_is_missing(input) {
+        Some("No snapshot is loaded — run `loct scan` before trusting ContextPack metrics. (RepoVerified)".to_string())
+    } else if input.pack.risk.stale_snapshot {
         Some("Snapshot is stale relative to current git HEAD — run `loct scan` before trusting derived facts. (RepoVerified)".to_string())
     } else if m.cycles_status.is_measured()
         && let MeasurementStatus::Measured(n) = &m.cycles_status
@@ -417,6 +428,12 @@ fn top_three_warnings(input: &PillInput<'_>, m: &Metrics) -> Vec<String> {
 
 fn collect_stale(input: &PillInput<'_>) -> Vec<String> {
     let mut out = Vec::new();
+    if snapshot_is_missing(input) {
+        out.push(
+            "No snapshot loaded: run `loct scan` before relying on derived file/import metrics. (RepoVerified)"
+                .to_string(),
+        );
+    }
     if input.pack.risk.stale_snapshot {
         out.push(format!(
             "Snapshot HEAD diverged from worktree HEAD ({}). (RepoVerified)",
@@ -449,6 +466,21 @@ fn collect_stale(input: &PillInput<'_>) -> Vec<String> {
         AicxRenderStatus::EnabledWithRows | AicxRenderStatus::Disabled => {}
     }
     out
+}
+
+fn snapshot_is_missing(input: &PillInput<'_>) -> bool {
+    matches!(input.pack.risk.cache_scope, RiskCacheScope::MissingSnapshot)
+        || input.pack.risk.snapshot_health.as_deref() == Some("missing_snapshot")
+}
+
+fn snapshot_state_label(input: &PillInput<'_>) -> &'static str {
+    if snapshot_is_missing(input) {
+        "no snapshot - run `loct scan`"
+    } else if input.pack.risk.stale_snapshot {
+        "stale"
+    } else {
+        "fresh"
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -1637,8 +1669,7 @@ mod tests {
     #[test]
     fn pill_aicx_memory_does_not_leak_absolute_aicx_store_paths() {
         let mut pack = fixture_pack();
-        let leaky_path =
-            "/home/tester/.aicx/store/Loctree/loctree-suite/2026_0525/conversations/claude/s1.md";
+        let leaky_path = "/home/polyversai/.aicx/store/Loctree/loctree-suite/2026_0525/conversations/claude/s1.md";
         pack.memory = MemorySlice {
             entries: vec![MemoryEntry {
                 kind: "decision".to_string(),
@@ -1663,7 +1694,7 @@ mod tests {
         let input = input_with(&pack, &scope, AicxRenderStatus::EnabledWithRows);
         let md = render_pill(input);
         assert!(
-            !md.contains("/home/tester/.aicx/store/"),
+            !md.contains("/home/polyversai/.aicx/store/"),
             "absolute aicx-store path must NOT leak into rendered context: {md}"
         );
         assert!(
@@ -1721,5 +1752,45 @@ mod tests {
         assert!(md.contains("2026-04-28T16:58:02Z"));
         assert!(md.contains("231 files"));
         assert!(md.contains("421 import edges"));
+    }
+
+    #[test]
+    fn pill_missing_snapshot_never_reports_zero_files_fresh() {
+        let mut pack = fixture_pack();
+        pack.risk.cache_scope = RiskCacheScope::MissingSnapshot;
+        pack.risk.cache_scope_authority = AuthorityLabel::RepoVerified;
+        pack.risk.snapshot_health = Some("missing_snapshot".to_string());
+        pack.risk.stale_snapshot = false;
+        pack.risk.hotspots.clear();
+        pack.risk.high_fan_in.clear();
+
+        let mut scope = fixture_scope();
+        scope.branch_hint = None;
+        scope.top_hubs.clear();
+        scope.recent_files.clear();
+        let input = PillInput {
+            pack: &pack,
+            scope: &scope,
+            project_name: "loctree-suite".to_string(),
+            timestamp_iso: "2026-07-06T09:00:00Z".to_string(),
+            snapshot_files: 0,
+            snapshot_edges: 0,
+            elapsed: std::time::Duration::from_millis(12),
+            aicx_status: AicxRenderStatus::Disabled,
+        };
+
+        let md = render_pill(input);
+        assert!(
+            md.contains("no snapshot - run `loct scan`"),
+            "missing snapshot must be explicit: {md}"
+        );
+        assert!(
+            !md.contains("0 files") && !md.contains("0 import edges"),
+            "missing snapshot must not masquerade as zero metrics: {md}"
+        );
+        assert!(
+            !md.contains("snapshot fresh"),
+            "missing snapshot must not render as fresh: {md}"
+        );
     }
 }

--- a/loctree-rs/src/cli/dispatch/handlers/doctor.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/doctor.rs
@@ -291,19 +291,19 @@ fn annotate_scope(entries: &mut Vec<CacheEntry>, requested_root: Option<&Path>) 
         entry.scope_state = Some(state);
     }
 
-    if entries.is_empty() {
-        if let Some(project_root) = requested_root {
-            entries.push(CacheEntry {
-                project_id: project_id_for(project_root),
-                canonical_root: Some(project_root.display().to_string()),
-                last_scan_branch: None,
-                last_scan_commit: None,
-                last_scan_mtime: None,
-                cache_size_bytes: None,
-                scope_state: Some(ScopeState::NotFound),
-                fix_command: Some(format!("loct scan --project {}", project_root.display())),
-            });
-        }
+    if entries.is_empty()
+        && let Some(project_root) = requested_root
+    {
+        entries.push(CacheEntry {
+            project_id: project_id_for(project_root),
+            canonical_root: Some(project_root.display().to_string()),
+            last_scan_branch: None,
+            last_scan_commit: None,
+            last_scan_mtime: None,
+            cache_size_bytes: None,
+            scope_state: Some(ScopeState::NotFound),
+            fix_command: Some(format!("loct scan --project {}", project_root.display())),
+        });
     }
 }
 
@@ -532,10 +532,10 @@ fn enumerate_cache_entries(target_id: Option<&str>) -> Result<Vec<CacheEntry>> {
         }
 
         let project_id = project_entry.file_name().to_string_lossy().to_string();
-        if let Some(wanted) = target_id {
-            if project_id != wanted {
-                continue;
-            }
+        if let Some(wanted) = target_id
+            && project_id != wanted
+        {
+            continue;
         }
 
         // From here on every path is derived from the iterator's own
@@ -549,20 +549,20 @@ fn enumerate_cache_entries(target_id: Option<&str>) -> Result<Vec<CacheEntry>> {
             project_dir.join("latest").join("snapshot.json"),
             project_dir.join("snapshot.json"),
         ] {
-            if let Ok(metadata) = fs::metadata(&fixed_path) {
-                if metadata.is_file() {
-                    if let Ok(modified) = metadata.modified() {
-                        candidates.push((fixed_path, modified));
-                        continue;
-                    }
-                    return Err(anyhow::anyhow!(
-                        "read mtime for cache project {project_id} snapshot {}",
-                        candidates
-                            .last()
-                            .map(|(p, _)| p.display().to_string())
-                            .unwrap_or_default()
-                    ));
+            if let Ok(metadata) = fs::metadata(&fixed_path)
+                && metadata.is_file()
+            {
+                if let Ok(modified) = metadata.modified() {
+                    candidates.push((fixed_path, modified));
+                    continue;
                 }
+                return Err(anyhow::anyhow!(
+                    "read mtime for cache project {project_id} snapshot {}",
+                    candidates
+                        .last()
+                        .map(|(p, _)| p.display().to_string())
+                        .unwrap_or_default()
+                ));
             }
         }
 
@@ -591,12 +591,11 @@ fn enumerate_cache_entries(target_id: Option<&str>) -> Result<Vec<CacheEntry>> {
                     continue;
                 }
                 let candidate_path = child.path().join("snapshot.json");
-                if let Ok(metadata) = fs::metadata(&candidate_path) {
-                    if metadata.is_file() {
-                        if let Ok(modified) = metadata.modified() {
-                            candidates.push((candidate_path, modified));
-                        }
-                    }
+                if let Ok(metadata) = fs::metadata(&candidate_path)
+                    && metadata.is_file()
+                    && let Ok(modified) = metadata.modified()
+                {
+                    candidates.push((candidate_path, modified));
                 }
             }
         }

--- a/loctree-rs/src/cli/dispatch/handlers/occurrences.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/occurrences.rs
@@ -3,15 +3,16 @@
 //! Loads (or creates) the snapshot, enumerates its files, reads each file's
 //! raw bytes, and reports every literal occurrence of the queried text.
 //! Identifier-like queries stay token-boundary aware; phrase/punctuation queries
-//! behave as fixed strings. No AST. No fuzz. "Not found" means not found.
+//! behave as fixed strings. Primary matches are never AST/fuzzy hits. Zero-hit
+//! output may add separate symbol-table near-match hints, never evidence.
 
 use std::path::{Path, PathBuf};
 
 use super::super::super::command::{FindOptions, OccurrencesOptions};
 use super::super::{DispatchResult, GlobalOptions, load_or_create_query_snapshot_for_roots};
 use crate::analyzer::occurrences::{
-    FileScope, OccurrenceResults, ReportOptions, ScanOptions, enrich_with_snapshot,
-    scan_files_with, scan_files_with_regex, scan_files_with_scope,
+    FileScope, OccurrenceResults, ReportOptions, ScanOptions, attach_near_matches,
+    enrich_with_snapshot, scan_files_with, scan_files_with_regex, scan_files_with_scope,
 };
 use crate::analyzer::search::{FuzzySuggestion, literal_fuzzy_suggestions};
 use crate::snapshot::Snapshot;
@@ -50,6 +51,7 @@ pub fn handle_occurrences_command(
         },
     );
     enrich_with_snapshot(&mut results, &snapshot);
+    attach_near_matches(&mut results, &snapshot.files);
     results.apply_report(ReportOptions {
         group_by_file: opts.group_by_file,
         count_only: opts.count_only,
@@ -66,7 +68,7 @@ pub fn handle_occurrences_command(
             }
         }
     } else {
-        print_human(&results);
+        print_human(&results, opts.compact);
     }
 
     DispatchResult::Exit(0)
@@ -122,6 +124,7 @@ pub fn handle_find_literal_command(opts: &FindOptions, global: &GlobalOptions) -
         },
     );
     enrich_with_snapshot(&mut literal_matches, &snapshot);
+    attach_near_matches(&mut literal_matches, &snapshot.files);
     literal_matches.apply_report(ReportOptions {
         group_by_file: opts.group_by_file,
         count_only: opts.count_only,
@@ -359,7 +362,11 @@ fn resolve_path(base: &Path, rel: &str) -> PathBuf {
     joined
 }
 
-fn print_human(results: &OccurrenceResults) {
+fn print_human(results: &OccurrenceResults, compact: bool) {
+    if compact {
+        print_compact(results);
+        return;
+    }
     println!(
         "Literal occurrences of '{}' ({} in {} file(s)) [source: {}]",
         results.query, results.total, results.files_matched, results.source
@@ -368,7 +375,7 @@ fn print_human(results: &OccurrenceResults) {
         println!("  {}", results.coverage_line);
     }
     if results.total == 0 {
-        println!("  (not found)");
+        print_no_exact_occurrences(results, "  ");
         print_suggested_next(results);
         return;
     }
@@ -400,6 +407,37 @@ fn print_human(results: &OccurrenceResults) {
         );
     }
     print_suggested_next(results);
+}
+
+fn print_compact(results: &OccurrenceResults) {
+    if results.total == 0 {
+        print_no_exact_occurrences(results, "");
+        return;
+    }
+    if results.slim {
+        println!("occurrence list suppressed; total={}", results.total);
+        return;
+    }
+    for occ in &results.occurrences {
+        println!("{}:{} {}", occ.file, occ.line, occ.context);
+    }
+}
+
+fn print_no_exact_occurrences(results: &OccurrenceResults, indent: &str) {
+    if results.near_matches.is_empty() {
+        println!("{}no exact occurrences of '{}'", indent, results.query);
+        return;
+    }
+    let symbols = results
+        .near_matches
+        .iter()
+        .map(|m| m.symbol.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!(
+        "{}no exact occurrences of '{}'; near-matches: {}",
+        indent, results.query, symbols
+    );
 }
 
 /// Render the per-file occurrence rollup, when `group_by_file` populated it.

--- a/loctree-rs/src/cli/dispatch/handlers/prune.rs
+++ b/loctree-rs/src/cli/dispatch/handlers/prune.rs
@@ -100,14 +100,14 @@ pub fn handle_prune_old_artifacts(opts: &PruneOldArtifactsOptions) -> DispatchRe
                 victim.path.display(),
                 victim.size_bytes as f64 / 1_048_576.0
             );
-            if opts.apply {
-                if let Err(err) = fs::remove_dir_all(&victim.path) {
-                    eprintln!(
-                        "    [error] failed to remove {}: {err}",
-                        victim.path.display()
-                    );
-                    continue;
-                }
+            if opts.apply
+                && let Err(err) = fs::remove_dir_all(&victim.path)
+            {
+                eprintln!(
+                    "    [error] failed to remove {}: {err}",
+                    victim.path.display()
+                );
+                continue;
             }
             total_removed_bytes = total_removed_bytes.saturating_add(victim.size_bytes);
             total_removed_dirs += 1;

--- a/loctree-rs/src/cli/parser/analysis_commands.rs
+++ b/loctree-rs/src/cli/parser/analysis_commands.rs
@@ -217,7 +217,7 @@ OPTIONS:
                                         accounting + context labels. For secret/privacy audits where
                                         --literal cannot evaluate a pattern. Mutually exclusive with --literal.
     --whole-token                       (literal) Treat '-' as token-internal: 'backdrop' no longer matches
-                                        inside 'overlay-backdrop'/'--sample-z-overlay-backdrop' (opt-in, no default change)
+                                        inside 'overlay-backdrop'/'--vista-z-overlay-backdrop' (opt-in, no default change)
     --group-by-file                     (literal) Add a per-file occurrence rollup ('by_file')
     --count-only, --slim                (literal) Suppress the full occurrence list, keep counters only
     --offset <N>                        (literal) Zero-based occurrence offset for paged output
@@ -468,9 +468,10 @@ DESCRIPTION:
 OPTIONS:
     --root <PATH>        Project root to scan (default: current directory)
     --whole-token        Treat '-' as token-internal: 'backdrop' no longer matches inside
-                         'overlay-backdrop'/'--sample-z-overlay-backdrop' (opt-in, no default change)
+                         'overlay-backdrop'/'--vista-z-overlay-backdrop' (opt-in, no default change)
     --group-by-file      Add a per-file occurrence rollup ('by_file')
     --count-only, --slim Suppress the full occurrence list, keep counters only ('slim')
+    --compact            Human output only: print path:line plus one context line per hit
     --limit <N>          Maximum number of occurrences to return in this page
     --offset <N>         Zero-based occurrence offset for paged output
     --json               Emit JSON (file, line, column, matched_text, context, source, occurrence_kind)
@@ -480,6 +481,7 @@ EXAMPLES:
     loct occurrences utterance_id
     loct occurrences utterance_id --json
     loct occurrences backdrop --whole-token            # Exclude hyphenated z-index noise
+    loct occurrences utterance_id --compact            # Terse path:line context for agents
     loct occurrences agent --limit 50 --offset 100 --json  # Page through large result sets
     loct occurrences backdrop --group-by-file --count-only --json  # Per-file counts, no list"
                 .to_string(),
@@ -509,6 +511,10 @@ EXAMPLES:
             }
             "--count-only" | "--slim" => {
                 opts.count_only = true;
+                i += 1;
+            }
+            "--compact" => {
+                opts.compact = true;
                 i += 1;
             }
             "--limit" => {

--- a/loctree-rs/src/cli/parser/core.rs
+++ b/loctree-rs/src/cli/parser/core.rs
@@ -14,7 +14,10 @@ use super::context_commands::{
     parse_context_command, parse_coverage_command, parse_focus_command, parse_follow_command,
     parse_hotspots_command, parse_repo_view_command, parse_slice_command, parse_trace_command,
 };
-use super::helpers::{SUBCOMMANDS, is_jq_filter, parse_color_mode, suggest_similar_command};
+use super::helpers::{
+    SUBCOMMANDS, format_unknown_subcommand_error, is_jq_filter, parse_color_mode,
+    should_treat_unknown_as_subcommand,
+};
 use super::misc_commands::{
     parse_audit_command, parse_cache_command, parse_crowd_command, parse_dist_command,
     parse_doctor_command, parse_env_truth_command, parse_health_command, parse_help_command,
@@ -96,7 +99,8 @@ pub fn uses_new_syntax(args: &[String]) -> bool {
         }
         return SUBCOMMANDS.contains(&arg.as_str())
             || Command::retired_command_message(arg).is_some()
-            || is_jq_filter(arg);
+            || is_jq_filter(arg)
+            || should_treat_unknown_as_subcommand(args, arg);
     }
     // No arguments = default to auto (new syntax)
     true
@@ -124,6 +128,7 @@ pub fn parse_command(args: &[String]) -> Result<Option<ParsedCommand>, String> {
     let mut help_requested = false;
     let mut legacy_findings_alias = false;
     let mut legacy_summary_only = false;
+    let mut unknown_subcommand: Option<String> = None;
 
     // Check for jq-style query before extracting global options
     // This allows: loct '.metadata' to work without conflicts
@@ -284,6 +289,11 @@ pub fn parse_command(args: &[String]) -> Result<Option<ParsedCommand>, String> {
                         || Command::retired_command_message(arg).is_some())
                 {
                     subcommand = Some(arg.clone());
+                } else if subcommand.is_none()
+                    && !legacy_findings_alias
+                    && should_treat_unknown_as_subcommand(args, arg)
+                {
+                    unknown_subcommand = Some(arg.clone());
                 } else {
                     remaining_args.push(arg.clone());
                 }
@@ -301,6 +311,10 @@ pub fn parse_command(args: &[String]) -> Result<Option<ParsedCommand>, String> {
             "`--findings` and bare `--summary` are no longer global output flags. Use `loct findings` or `loct findings --summary`."
                 .to_string(),
         );
+    }
+
+    if let Some(unknown) = unknown_subcommand {
+        return Err(format_unknown_subcommand_error(&unknown));
     }
 
     if help_requested {
@@ -420,15 +434,7 @@ pub fn parse_command(args: &[String]) -> Result<Option<ParsedCommand>, String> {
         Some("plan") | Some("p") => parse_plan_command(&remaining_args)?,
         Some("cache") => parse_cache_command(&remaining_args)?,
         Some("prune-old-artifacts") => parse_prune_old_artifacts_command(&remaining_args)?,
-        Some(unknown) => {
-            // Try to find a similar command using fuzzy matching
-            let suggestion = suggest_similar_command(unknown);
-            return Err(format!(
-                "Unknown command '{}'. {}Run 'loct --help' for available commands.",
-                unknown,
-                suggestion.map_or(String::new(), |s| format!("Did you mean: {}?\n", s))
-            ));
-        }
+        Some(unknown) => return Err(format_unknown_subcommand_error(unknown)),
     };
 
     if for_ai_alias {
@@ -751,6 +757,48 @@ mod tests {
         let args = vec!["--tree".into()];
         let result = parse_command(&args).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_unknown_bare_token_with_help_errors_as_subcommand() {
+        let args = vec!["blame".into(), "--help".into()];
+        let err = parse_command(&args).unwrap_err();
+        assert!(
+            err.contains("unknown subcommand 'blame'"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("did you mean 'plan'?"),
+            "unknown subcommand should include a suggestion: {err}"
+        );
+        assert!(
+            err.contains("Commands include:"),
+            "error should include a short command list: {err}"
+        );
+        assert!(
+            !err.contains("Path 'blame'"),
+            "unknown subcommand must not fall through to path validation: {err}"
+        );
+    }
+
+    #[test]
+    fn test_unknown_subcommand_typo_suggests_real_command() {
+        let args = vec!["contezt".into()];
+        let err = parse_command(&args).unwrap_err();
+        assert!(
+            err.contains("unknown subcommand 'contezt', did you mean 'context'?"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_existing_path_positional_still_falls_back_to_legacy_parser() {
+        let args = vec!["Cargo.toml".into(), "--help".into()];
+        let result = parse_command(&args).unwrap();
+        assert!(
+            result.is_none(),
+            "existing paths must keep legacy positional behavior"
+        );
     }
 
     #[test]

--- a/loctree-rs/src/cli/parser/helpers.rs
+++ b/loctree-rs/src/cli/parser/helpers.rs
@@ -5,6 +5,8 @@
 //! - JQ filter detection
 //! - Command suggestion via Levenshtein distance
 
+use std::path::Path;
+
 use strsim::levenshtein;
 
 use crate::types::ColorMode;
@@ -71,23 +73,47 @@ pub(crate) const SUBCOMMANDS: &[&str] = &[
     "prune-old-artifacts",
 ];
 
+const LEGACY_POSITIONAL_COMMANDS: &[&str] = &["tauri", "styles", "init", "search", "git", "for-ai"];
+
 /// Check if an argument looks like a new-style subcommand.
 pub fn is_subcommand(arg: &str) -> bool {
     SUBCOMMANDS.contains(&arg)
 }
 
+pub(super) fn should_treat_unknown_as_subcommand(args: &[String], input: &str) -> bool {
+    if input.is_empty()
+        || input.starts_with('-')
+        || is_jq_filter(input)
+        || SUBCOMMANDS.contains(&input)
+        || LEGACY_POSITIONAL_COMMANDS.contains(&input)
+        || Path::new(input).exists()
+    {
+        return false;
+    }
+
+    let help_requested = args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h"));
+
+    help_requested || !looks_path_like(input)
+}
+
 /// Suggest a similar command using Levenshtein distance.
-/// Returns Some(suggestion) if a close match is found (distance <= 2).
+/// Returns Some(suggestion) if a close match is found.
 pub(super) fn suggest_similar_command(input: &str) -> Option<&'static str> {
     let input_lower = input.to_lowercase();
     let mut best_match: Option<(&str, usize)> = None;
+    let max_distance = if input_lower.len() >= 5 { 3 } else { 2 };
 
     for &cmd in SUBCOMMANDS {
         let distance = levenshtein(&input_lower, cmd);
-        // Only suggest if distance is small (max 2 for reasonable similarity)
-        if distance <= 2 {
-            if let Some((_, best_dist)) = best_match {
-                if distance < best_dist {
+        if distance <= max_distance {
+            if let Some((best_cmd, best_dist)) = best_match {
+                if distance < best_dist
+                    || (distance == best_dist
+                        && (cmd.len() < best_cmd.len()
+                            || (cmd.len() == best_cmd.len() && cmd < best_cmd)))
+                {
                     best_match = Some((cmd, distance));
                 }
             } else {
@@ -97,6 +123,19 @@ pub(super) fn suggest_similar_command(input: &str) -> Option<&'static str> {
     }
 
     best_match.map(|(cmd, _)| cmd)
+}
+
+pub(super) fn format_unknown_subcommand_error(input: &str) -> String {
+    let mut message = format!("unknown subcommand '{}'", input);
+    if let Some(suggestion) = suggest_similar_command(input) {
+        message.push_str(&format!(", did you mean '{}'?", suggestion));
+    } else {
+        message.push('.');
+    }
+    message.push_str(
+        "\nCommands include: auto, scan, tree, slice, context, repo-view, find, occurrences, findings, dead, cycles, trace, impact, focus, follow, doctor.\nRun 'loct --help' for available commands.",
+    );
+    message
 }
 
 /// Check if argument looks like a jq filter expression
@@ -123,6 +162,15 @@ pub(super) fn is_jq_filter(arg: &str) -> bool {
         return true;
     }
     false
+}
+
+fn looks_path_like(input: &str) -> bool {
+    input == "."
+        || input == ".."
+        || input.starts_with('~')
+        || input.contains('/')
+        || input.contains('\\')
+        || Path::new(input).extension().is_some()
 }
 
 /// Parse color mode from string value.

--- a/loctree-rs/src/cli/parser/misc_commands.rs
+++ b/loctree-rs/src/cli/parser/misc_commands.rs
@@ -152,10 +152,10 @@ pub(super) fn parse_tagmap_command(args: &[String]) -> Result<Command, String> {
 
 /// Parse `loct prism --task A --task B [options]` command.
 pub(super) fn parse_prism_command(args: &[String]) -> Result<Command, String> {
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        if let Some(help) = Command::format_command_help("prism") {
-            return Err(help.to_string());
-        }
+    if args.iter().any(|a| a == "--help" || a == "-h")
+        && let Some(help) = Command::format_command_help("prism")
+    {
+        return Err(help.to_string());
     }
 
     let mut opts = PrismOptions::default();
@@ -326,10 +326,10 @@ EXAMPLES:
 /// Parse `loct dist [options]` command - analyze bundle distribution.
 pub(super) fn parse_dist_command(args: &[String]) -> Result<Command, String> {
     // Check for help flag first
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        if let Some(help) = Command::format_command_help("dist") {
-            return Err(help.to_string());
-        }
+    if args.iter().any(|a| a == "--help" || a == "-h")
+        && let Some(help) = Command::format_command_help("dist")
+    {
+        return Err(help.to_string());
     }
 
     let mut opts = DistOptions::default();

--- a/loctree-rs/src/focuser.rs
+++ b/loctree-rs/src/focuser.rs
@@ -530,24 +530,24 @@ mod tests {
                 git_scan_id: None,
             },
             files: vec![
-                // Files in src/features/settings/
+                // Files in src/features/patients/
                 FileAnalysis {
-                    path: "src/features/settings/index.ts".to_string(),
+                    path: "src/features/patients/index.ts".to_string(),
                     loc: 20,
                     language: "typescript".to_string(),
-                    ..FileAnalysis::new("src/features/settings/index.ts".to_string())
+                    ..FileAnalysis::new("src/features/patients/index.ts".to_string())
                 },
                 FileAnalysis {
-                    path: "src/features/settings/SettingsList.tsx".to_string(),
+                    path: "src/features/patients/PatientsList.tsx".to_string(),
                     loc: 150,
                     language: "typescript".to_string(),
-                    ..FileAnalysis::new("src/features/settings/SettingsList.tsx".to_string())
+                    ..FileAnalysis::new("src/features/patients/PatientsList.tsx".to_string())
                 },
                 FileAnalysis {
-                    path: "src/features/settings/useSetting.ts".to_string(),
+                    path: "src/features/patients/usePatient.ts".to_string(),
                     loc: 80,
                     language: "typescript".to_string(),
-                    ..FileAnalysis::new("src/features/settings/useSetting.ts".to_string())
+                    ..FileAnalysis::new("src/features/patients/usePatient.ts".to_string())
                 },
                 // External files
                 FileAnalysis {
@@ -570,32 +570,32 @@ mod tests {
                 },
             ],
             edges: vec![
-                // Internal edges (within settings/)
+                // Internal edges (within patients/)
                 GraphEdge {
-                    from: "src/features/settings/index.ts".to_string(),
-                    to: "src/features/settings/SettingsList.tsx".to_string(),
+                    from: "src/features/patients/index.ts".to_string(),
+                    to: "src/features/patients/PatientsList.tsx".to_string(),
                     label: "reexport".to_string(),
                 },
                 GraphEdge {
-                    from: "src/features/settings/SettingsList.tsx".to_string(),
-                    to: "src/features/settings/useSetting.ts".to_string(),
+                    from: "src/features/patients/PatientsList.tsx".to_string(),
+                    to: "src/features/patients/usePatient.ts".to_string(),
                     label: "import".to_string(),
                 },
-                // External deps (settings imports external)
+                // External deps (patients imports external)
                 GraphEdge {
-                    from: "src/features/settings/SettingsList.tsx".to_string(),
+                    from: "src/features/patients/PatientsList.tsx".to_string(),
                     to: "src/components/Button.tsx".to_string(),
                     label: "import".to_string(),
                 },
                 GraphEdge {
-                    from: "src/features/settings/useSetting.ts".to_string(),
+                    from: "src/features/patients/usePatient.ts".to_string(),
                     to: "src/utils/api.ts".to_string(),
                     label: "import".to_string(),
                 },
-                // Consumer (App imports settings)
+                // Consumer (App imports patients)
                 GraphEdge {
                     from: "src/App.tsx".to_string(),
-                    to: "src/features/settings/index.ts".to_string(),
+                    to: "src/features/patients/index.ts".to_string(),
                     label: "import".to_string(),
                 },
             ],
@@ -613,10 +613,10 @@ mod tests {
         let snapshot = create_test_snapshot();
         let config = FocusConfig::default();
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
-            .expect("focus on settings");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
+            .expect("focus on patients");
 
-        assert_eq!(focus.target, "src/features/settings");
+        assert_eq!(focus.target, "src/features/patients");
         assert_eq!(focus.stats.core_files, 3);
         assert_eq!(focus.stats.core_loc, 250); // 20 + 150 + 80
     }
@@ -626,10 +626,10 @@ mod tests {
         let snapshot = create_test_snapshot();
         let config = FocusConfig::default();
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
-            .expect("focus on settings");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
+            .expect("focus on patients");
 
-        // Two internal edges: index->SettingsList, SettingsList->useSetting
+        // Two internal edges: index->PatientsList, PatientsList->usePatient
         assert_eq!(focus.stats.internal_edges, 2);
     }
 
@@ -638,10 +638,10 @@ mod tests {
         let snapshot = create_test_snapshot();
         let config = FocusConfig::default();
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
-            .expect("focus on settings");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
+            .expect("focus on patients");
 
-        // SettingsList imports Button, useSetting imports api
+        // PatientsList imports Button, usePatient imports api
         assert_eq!(focus.stats.deps_files, 2);
         let dep_paths: Vec<_> = focus.deps.iter().map(|f| f.path.as_str()).collect();
         assert!(dep_paths.contains(&"src/components/Button.tsx"));
@@ -654,10 +654,10 @@ mod tests {
         let index = snapshot
             .files
             .iter_mut()
-            .find(|file| file.path == "src/features/settings/index.ts")
+            .find(|file| file.path == "src/features/patients/index.ts")
             .expect("fixture index.ts");
         index.exports.push(crate::types::ExportSymbol {
-            name: "SettingsModule".to_string(),
+            name: "PatientsModule".to_string(),
             kind: "function".to_string(),
             export_type: "named".to_string(),
             line: Some(3),
@@ -667,10 +667,10 @@ mod tests {
 
         let focus = HolographicFocus::from_path(
             &snapshot,
-            "src/features/settings",
+            "src/features/patients",
             &FocusConfig::default(),
         )
-        .expect("focus on settings");
+        .expect("focus on patients");
         let json = focus.to_json();
 
         assert_eq!(
@@ -684,8 +684,8 @@ mod tests {
                 .expect("coreSymbols")
                 .iter()
                 .any(|symbol| {
-                    symbol["name"] == "SettingsModule"
-                        && symbol["file"] == "src/features/settings/index.ts"
+                    symbol["name"] == "PatientsModule"
+                        && symbol["file"] == "src/features/patients/index.ts"
                         && symbol["line"] == 3
                         && symbol["authority"] == "LoctreeDerived"
                 }),
@@ -696,7 +696,7 @@ mod tests {
                 .as_array()
                 .expect("suggestedNext")
                 .iter()
-                .any(|step| step["command"] == "loct occurrences 'SettingsModule' --json"),
+                .any(|step| step["command"] == "loct occurrences 'PatientsModule' --json"),
             "focus should carry non-empty suggested next steps: {json}"
         );
     }
@@ -709,10 +709,10 @@ mod tests {
             ..Default::default()
         };
 
-        let focus = HolographicFocus::from_path(&snapshot, "src/features/settings", &config)
-            .expect("focus on settings with consumers");
+        let focus = HolographicFocus::from_path(&snapshot, "src/features/patients", &config)
+            .expect("focus on patients with consumers");
 
-        // App.tsx imports from settings
+        // App.tsx imports from patients
         assert_eq!(focus.stats.consumers_files, 1);
         assert_eq!(focus.consumers[0].path, "src/App.tsx");
     }
@@ -732,9 +732,9 @@ mod tests {
         let config = FocusConfig::default();
 
         // All these should work the same
-        let f1 = HolographicFocus::from_path(&snapshot, "src/features/settings", &config);
-        let f2 = HolographicFocus::from_path(&snapshot, "src/features/settings/", &config);
-        let f3 = HolographicFocus::from_path(&snapshot, "./src/features/settings", &config);
+        let f1 = HolographicFocus::from_path(&snapshot, "src/features/patients", &config);
+        let f2 = HolographicFocus::from_path(&snapshot, "src/features/patients/", &config);
+        let f3 = HolographicFocus::from_path(&snapshot, "./src/features/patients", &config);
 
         assert!(f1.is_some());
         assert!(f2.is_some());

--- a/loctree-rs/src/fs_utils.rs
+++ b/loctree-rs/src/fs_utils.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
@@ -516,7 +516,7 @@ fn matchers_exclude(matchers: &IgnoreMatchers, abs_path: &Path) -> bool {
 /// not loctignore-excluded. This lets callers (focus / slice) distinguish
 /// "wrong path — check it" from "right path, but parked outside the snapshot by
 /// .loctignore", instead of misleadingly telling the user to check a path that
-/// is in fact correct (loctree-feedback.md: example-app `docs/` excluded by .loctignore).
+/// is in fact correct (loctree-feedback.md: vista `docs/` excluded by .loctignore).
 pub fn loctignore_exclusion_hint(root: &Path, target: &str) -> Option<String> {
     let abs = root.join(target);
     if !abs.exists() {
@@ -599,22 +599,21 @@ pub fn matches_extension(
             {
                 return true;
             }
-            if let Some(ext) = path.extension().and_then(|ext| ext.to_str()) {
-                if set.contains(&ext.to_lowercase()) {
-                    return true;
-                }
+            if let Some(ext) = path.extension().and_then(|ext| ext.to_str())
+                && set.contains(&ext.to_lowercase())
+            {
+                return true;
             }
             // Filename-based match for extensionless files (Makefile family)
             // — only when the allowed set actually opted into make parsing.
-            if set.contains("mk") || set.contains("make") {
-                if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
-                    if matches!(
-                        filename,
-                        "Makefile" | "makefile" | "GNUmakefile" | "BSDmakefile"
-                    ) {
-                        return true;
-                    }
-                }
+            if (set.contains("mk") || set.contains("make"))
+                && let Some(filename) = path.file_name().and_then(|n| n.to_str())
+                && matches!(
+                    filename,
+                    "Makefile" | "makefile" | "GNUmakefile" | "BSDmakefile"
+                )
+            {
+                return true;
             }
             false
         }
@@ -712,13 +711,13 @@ pub fn matches_extensionless_source_shebang(
         return false;
     }
     // Skip the Makefile-family names we already classify as `make` above.
-    if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
-        if matches!(
+    if let Some(filename) = path.file_name().and_then(|n| n.to_str())
+        && matches!(
             filename,
             "Makefile" | "makefile" | "GNUmakefile" | "BSDmakefile"
-        ) {
-            return false;
-        }
+        )
+    {
+        return false;
     }
     let Ok(file) = File::open(path) else {
         return false;
@@ -733,6 +732,32 @@ pub fn matches_extensionless_source_shebang(
         .is_some_and(|ext| extension_set_accepts_shebang_source(ext, extensions))
 }
 
+const EXTENSIONLESS_TEXT_SNIFF_BYTES: usize = 512;
+
+/// Generic fallback for extensionless text that should participate in literal
+/// truth surfaces (LICENSE, Dockerfile, CODEOWNERS, extensionless scripts).
+/// Reads only a small prefix and accepts files whose prefix contains no NUL.
+pub fn matches_extensionless_text(path: &Path) -> bool {
+    if path.extension().is_some() {
+        return false;
+    }
+    if let Some(filename) = path.file_name().and_then(|n| n.to_str())
+        && filename.starts_with('.')
+        && !is_hidden_truth_config_filename(filename)
+    {
+        return false;
+    }
+
+    let Ok(mut file) = File::open(path) else {
+        return false;
+    };
+    let mut buffer = [0u8; EXTENSIONLESS_TEXT_SNIFF_BYTES];
+    let Ok(read) = file.read(&mut buffer) else {
+        return false;
+    };
+    !buffer[..read].contains(&0)
+}
+
 pub fn matches_extensionless_shell(
     path: &Path,
     extensions: Option<&std::collections::HashSet<String>>,
@@ -743,13 +768,13 @@ pub fn matches_extensionless_shell(
     if path.extension().is_some() {
         return false;
     }
-    if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
-        if matches!(
+    if let Some(filename) = path.file_name().and_then(|n| n.to_str())
+        && matches!(
             filename,
             "Makefile" | "makefile" | "GNUmakefile" | "BSDmakefile"
-        ) {
-            return false;
-        }
+        )
+    {
+        return false;
     }
     let Ok(file) = File::open(path) else {
         return false;
@@ -969,7 +994,8 @@ fn gather_files_inner(
                 )?;
             } else if meta.is_file()
                 && (matches_extension(&target, options.extensions.as_ref())
-                    || matches_extensionless_source_shebang(&target, options.extensions.as_ref()))
+                    || matches_extensionless_source_shebang(&target, options.extensions.as_ref())
+                    || matches_extensionless_text(&target))
             {
                 files.push(target);
             }
@@ -980,6 +1006,7 @@ fn gather_files_inner(
             let canonical = path.canonicalize().unwrap_or(path.clone());
             if matches_extension(&canonical, options.extensions.as_ref())
                 || matches_extensionless_source_shebang(&canonical, options.extensions.as_ref())
+                || matches_extensionless_text(&canonical)
             {
                 files.push(canonical);
             }
@@ -1436,6 +1463,60 @@ mod tests {
     }
 
     #[test]
+    fn test_gather_files_collects_extensionless_text_but_not_binary() {
+        let tmp = tempfile::tempdir().expect("tmp dir");
+        let root = tmp.path();
+
+        std::fs::write(root.join("LICENSE"), "extensionless license text\n")
+            .expect("write LICENSE");
+        std::fs::write(root.join("Dockerfile"), "FROM scratch\n").expect("write Dockerfile");
+        std::fs::write(root.join("CODEOWNERS"), "* @loctree/team\n").expect("write CODEOWNERS");
+        std::fs::write(root.join("plain-script"), "echo no shebang but text\n")
+            .expect("write plain-script");
+        std::fs::write(root.join("blob"), b"\x7fELF\0not text").expect("write blob");
+        std::fs::write(root.join(".env"), "SECRET_SHOULD_NOT_ENTER=1\n").expect("write .env");
+
+        let exts: HashSet<String> = ["rs", "make", "mk"]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        let options = crate::types::Options {
+            extensions: Some(exts),
+            ..Default::default()
+        };
+        let mut visited = HashSet::new();
+        let mut files: Vec<PathBuf> = Vec::new();
+        gather_files(root, &options, 0, None, &mut visited, &mut files).expect("gather");
+
+        let names: Vec<String> = files
+            .iter()
+            .filter_map(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string())
+            })
+            .collect();
+
+        for expected in ["LICENSE", "Dockerfile", "CODEOWNERS", "plain-script"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "{expected} missing from extensionless text collection: {:?}",
+                names
+            );
+        }
+        assert!(
+            !names.iter().any(|n| n == "blob"),
+            "NUL-bearing extensionless binary must stay out of collection: {:?}",
+            names
+        );
+        assert!(
+            !names.iter().any(|n| n == ".env"),
+            "generic hidden extensionless files must not enter via text sniff: {:?}",
+            names
+        );
+    }
+
+    #[test]
     fn test_is_allowed_hidden() {
         // Allowed hidden files
         assert!(is_allowed_hidden(".env"));
@@ -1613,7 +1694,7 @@ mod tests {
 
     #[test]
     fn loctignore_exclusion_hint_distinguishes_ignored_from_wrong_path() {
-        // loctree-feedback.md (2026-06-25, example-app): focus(docs)/slice fell back with
+        // loctree-feedback.md (2026-06-25, vista): focus(docs)/slice fell back with
         // "No files found. Check the path." when docs/ EXISTS on disk but is
         // excluded by .loctignore. The hint must name .loctignore so the agent
         // does not chase a wrong-path that is actually correct.

--- a/loctree-rs/src/pack.rs
+++ b/loctree-rs/src/pack.rs
@@ -1190,9 +1190,9 @@ fn parse_duration_env(raw: &str) -> Option<Duration> {
 
 fn format_duration(duration: Duration) -> String {
     let secs = duration.as_secs();
-    if secs % (60 * 60) == 0 {
+    if secs.is_multiple_of(60 * 60) {
         format!("{}h", secs / (60 * 60))
-    } else if secs % 60 == 0 {
+    } else if secs.is_multiple_of(60) {
         format!("{}m", secs / 60)
     } else {
         format!("{secs}s")
@@ -1662,10 +1662,10 @@ fn collect_tauri_commands(bridges: &[CommandBridge], target: &str, slice: &mut R
 }
 
 fn tauri_command_in_scope(bridge: &CommandBridge, target: &str) -> bool {
-    if let Some((file, _)) = &bridge.backend_handler {
-        if file == target {
-            return true;
-        }
+    if let Some((file, _)) = &bridge.backend_handler
+        && file == target
+    {
+        return true;
     }
     bridge.frontend_calls.iter().any(|(file, _)| file == target)
 }

--- a/loctree-rs/src/semantic/c_family.rs
+++ b/loctree-rs/src/semantic/c_family.rs
@@ -166,16 +166,16 @@ fn swift_hits(file: &str, source: &str) -> Vec<RuntimeHit> {
             continue;
         }
         let window = call_window(source, idx, 6);
-        if window.contains("NotificationCenter") || window.contains("name:") {
-            if let Some(name) = extract_argument_name(window, &["name:"]) {
-                hits.push(RuntimeHit {
-                    line: line_number(source, idx),
-                    name,
-                    edge_kind: SymbolEdgeKind::NotificationEmit,
-                    source_kind: "notification_emit_site",
-                    target_kind: "notification",
-                });
-            }
+        if (window.contains("NotificationCenter") || window.contains("name:"))
+            && let Some(name) = extract_argument_name(window, &["name:"])
+        {
+            hits.push(RuntimeHit {
+                line: line_number(source, idx),
+                name,
+                edge_kind: SymbolEdgeKind::NotificationEmit,
+                source_kind: "notification_emit_site",
+                target_kind: "notification",
+            });
         }
     }
     for (idx, _) in source.match_indices("addObserver") {

--- a/loctree-rs/src/semantic/shell.rs
+++ b/loctree-rs/src/semantic/shell.rs
@@ -1181,7 +1181,7 @@ echo "${LANG:-en_US.UTF-8}"
 
     #[test]
     fn env_contract_skips_locally_assigned_uppercase_vars() {
-        // W2-c regression (codescribe 126 / suite 152 false orphans):
+        // W2-c regression (CodeScribe 126 / suite 152 false orphans):
         // `APP_NAME=x` + `echo $APP_NAME` is a script-local variable, not an
         // env contract. Same for ANSI color locals and loop variables.
         let tmp = tempfile::tempdir().unwrap();

--- a/loctree-rs/src/snapshot.rs
+++ b/loctree-rs/src/snapshot.rs
@@ -2280,16 +2280,15 @@ impl Snapshot {
     /// This is a lightweight check (commit hash comparison only).
     /// Returns `false` for non-git directories.
     pub fn is_commit_stale(&self, root: &Path) -> bool {
-        if let Some(snapshot_commit) = &self.metadata.git_commit {
-            if let Ok(repo) = crate::git::GitRepo::discover(root) {
-                if let Ok(current_commit) = repo.head_commit() {
-                    // Snapshot stores short hash, head_commit() returns full —
-                    // prefix comparison handles both directions.
-                    let is_same = current_commit.starts_with(snapshot_commit)
-                        || snapshot_commit.starts_with(&current_commit);
-                    return !is_same;
-                }
-            }
+        if let Some(snapshot_commit) = &self.metadata.git_commit
+            && let Ok(repo) = crate::git::GitRepo::discover(root)
+            && let Ok(current_commit) = repo.head_commit()
+        {
+            // Snapshot stores short hash, head_commit() returns full —
+            // prefix comparison handles both directions.
+            let is_same = current_commit.starts_with(snapshot_commit)
+                || snapshot_commit.starts_with(&current_commit);
+            return !is_same;
         }
         false
     }
@@ -5712,20 +5711,20 @@ mod cache_tests {
     #[test]
     fn snapshot_parse_owner_repo_https() {
         assert_eq!(
-            parse_owner_repo("https://github.com/Loctree/loctree.git"),
-            Some("Loctree/loctree".to_string()),
+            parse_owner_repo("https://github.com/polyversai/loctree.git"),
+            Some("polyversai/loctree".to_string()),
         );
         assert_eq!(
-            parse_owner_repo("https://github.com/Loctree/loctree"),
-            Some("Loctree/loctree".to_string()),
+            parse_owner_repo("https://github.com/polyversai/loctree"),
+            Some("polyversai/loctree".to_string()),
         );
     }
 
     #[test]
     fn snapshot_parse_owner_repo_ssh() {
         assert_eq!(
-            parse_owner_repo("git@github.com:Loctree/loctree.git"),
-            Some("Loctree/loctree".to_string()),
+            parse_owner_repo("git@github.com:polyversai/loctree.git"),
+            Some("polyversai/loctree".to_string()),
         );
         assert_eq!(
             parse_owner_repo("git@gitlab.example.com:org/sub-repo.git"),
@@ -5746,11 +5745,11 @@ mod cache_tests {
     #[test]
     fn snapshot_parse_repo_name_extracts_last_segment() {
         assert_eq!(
-            parse_repo_name("https://github.com/Loctree/loctree.git"),
+            parse_repo_name("https://github.com/polyversai/loctree.git"),
             Some("loctree".to_string()),
         );
         assert_eq!(
-            parse_repo_name("git@github.com:Loctree/loctree.git"),
+            parse_repo_name("git@github.com:polyversai/loctree.git"),
             Some("loctree".to_string()),
         );
     }
@@ -5810,7 +5809,7 @@ mod cache_tests {
             entrypoints: Vec::new(),
             entrypoint_drift: EntrypointDriftSummary::default(),
             git_repo: Some("loctree".to_string()),
-            git_owner_repo: Some("Loctree/loctree".to_string()),
+            git_owner_repo: Some("polyversai/loctree".to_string()),
             git_branch: Some("main".to_string()),
             git_commit: Some("d6ecd24".to_string()),
             git_scan_id: Some("main@d6ecd24".to_string()),
@@ -5820,7 +5819,7 @@ mod cache_tests {
         let deser: SnapshotMetadata = serde_json::from_str(&json).expect("deserialize");
 
         assert_eq!(deser.git_repo, Some("loctree".to_string()));
-        assert_eq!(deser.git_owner_repo, Some("Loctree/loctree".to_string()));
+        assert_eq!(deser.git_owner_repo, Some("polyversai/loctree".to_string()));
         assert_eq!(deser.git_branch, Some("main".to_string()));
         assert_eq!(deser.git_commit, Some("d6ecd24".to_string()));
     }

--- a/loctree-rs/tests/e2e_cli.rs
+++ b/loctree-rs/tests/e2e_cli.rs
@@ -121,6 +121,44 @@ mod cli_basics {
     }
 
     #[test]
+    fn unknown_top_level_subcommand_does_not_fall_through_to_path() {
+        loct()
+            .args(["blame", "--help"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("unknown subcommand 'blame'"))
+            .stderr(predicate::str::contains("did you mean 'plan'?"))
+            .stderr(predicate::str::contains("Commands include:"))
+            .stderr(predicate::str::contains("Path 'blame'").not());
+    }
+
+    #[test]
+    fn unknown_top_level_subcommand_typo_suggests_real_command() {
+        loct()
+            .args(["contezt", "--help"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "unknown subcommand 'contezt', did you mean 'context'?",
+            ));
+    }
+
+    #[test]
+    fn existing_path_named_like_unknown_command_still_uses_path_flow() {
+        let temp = TempDir::new().unwrap();
+        std::fs::create_dir(temp.path().join("blame")).unwrap();
+
+        loct()
+            .current_dir(temp.path())
+            .args(["blame", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Static Analysis for AI Agents"))
+            .stderr(predicate::str::contains("unknown subcommand").not())
+            .stderr(predicate::str::contains("Path 'blame'").not());
+    }
+
+    #[test]
     fn full_help_has_no_duplicate_command_table_lines_or_stale_timings() {
         let output = loct()
             .arg("--help-full")
@@ -4291,7 +4329,10 @@ mod management_commands {
             "report must start with DOCTYPE, got first chars: {:?}",
             html.chars().take(40).collect::<String>()
         );
-        assert!(html.contains("Loctree Report"), "missing report title");
+        assert!(
+            html.contains("Loctree Report"),
+            "missing Vista report title"
+        );
         assert!(
             html.contains(env!("CARGO_PKG_VERSION")),
             "missing loctree binary version ({}) in rendered provenance chip",
@@ -5435,13 +5476,13 @@ mod env_truth {
         assert!(stdout.contains("sha256:"));
     }
 
-    /// W2-c: default report stays small even on a codescribe-like surface
+    /// W2-c: default report stays small even on a CodeScribe-like surface
     /// (the 2026-line wall regression).
     #[test]
     fn default_report_is_bounded_under_200_lines() {
         let temp = TempDir::new().unwrap();
         stage_env_drift(&temp, 30, 2);
-        // Add a codescribe-like pile of one-off declarations to fatten the
+        // Add a CodeScribe-like pile of one-off declarations to fatten the
         // would-be full dump.
         let mut extra = String::new();
         for i in 0..120 {
@@ -5665,7 +5706,7 @@ mod env_truth {
 mod occurrences_cli {
     use super::*;
 
-    /// W1-A regression — the codescribe `utterance_id` failure class.
+    /// W1-A regression — the CodeScribe `utterance_id` failure class.
     ///
     /// `loct occurrences <ident>` must find LOCAL-variable occurrences buried
     /// inside a large function — exactly the case `find`/`tagmap` missed (they
@@ -6084,6 +6125,133 @@ mod occurrences_cli {
                     .contains("without treating suggestions as evidence")),
             "zero literal results must suggest broadening without pretending suggestions are evidence"
         );
+        assert!(
+            json.get("near_matches")
+                .and_then(Value::as_array)
+                .is_none_or(|near| near.is_empty()),
+            "unrelated zero-hit query must not invent near matches: {json}"
+        );
+    }
+
+    #[test]
+    fn occurrences_zero_results_suggest_prefix_matches_from_symbol_table() {
+        let temp = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub struct MissingSymbolExtra;\n\
+             pub fn MissingSymbolFactory() {}\n\
+             fn helper_for_MissingSymbol() {}\n\
+             pub fn unrelated() {}\n",
+        )
+        .unwrap();
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["add", "."]);
+
+        let output = loctree()
+            .current_dir(temp.path())
+            .env("LOCT_CACHE_DIR", cache.path())
+            .args(["occurrences", "MissingSymbol", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json: Value =
+            serde_json::from_slice(&output).expect("occurrences --json must be valid JSON");
+        assert_eq!(json["total"], 0, "prefix-only symbols are not exact hits");
+
+        let near = json["near_matches"]
+            .as_array()
+            .expect("zero-hit result should carry near_matches when symbol-table names are close");
+        let symbols: Vec<&str> = near.iter().filter_map(|m| m["symbol"].as_str()).collect();
+        assert!(
+            symbols.contains(&"MissingSymbolExtra")
+                && symbols.contains(&"MissingSymbolFactory")
+                && symbols.contains(&"helper_for_MissingSymbol"),
+            "expected prefix/substring symbol hints, got {json}"
+        );
+        assert!(
+            near.iter().all(|m| m["source"] == "symbol_table"
+                && (m["match_kind"] == "prefix" || m["match_kind"] == "substring")),
+            "near matches must be separate symbol-table hints, not literal evidence: {json}"
+        );
+    }
+
+    #[test]
+    fn occurrences_zero_results_suggest_fuzzy_symbol_table_matches() {
+        let temp = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub fn handle_follow_command() {}\n",
+        )
+        .unwrap();
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["add", "."]);
+        let typo = ["handle_folow", "command"].join("_");
+
+        let output = loctree()
+            .current_dir(temp.path())
+            .env("LOCT_CACHE_DIR", cache.path())
+            .args(["occurrences", typo.as_str(), "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json: Value =
+            serde_json::from_slice(&output).expect("occurrences --json must be valid JSON");
+        assert_eq!(json["total"], 0, "typo hints are not literal hits");
+
+        let near = json["near_matches"]
+            .as_array()
+            .expect("zero-hit typo should carry near_matches from the symbol table");
+        assert!(
+            near.iter().any(|m| m["symbol"] == "handle_follow_command"
+                && m["match_kind"] == "fuzzy"
+                && m["source"] == "symbol_table"),
+            "expected fuzzy symbol-table hint, got {json}"
+        );
+    }
+
+    #[test]
+    fn occurrences_compact_output_is_path_line_context_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub fn target_ident() {}\npub fn call() { target_ident(); }\n",
+        )
+        .unwrap();
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["add", "."]);
+
+        let output = loctree()
+            .current_dir(temp.path())
+            .env("LOCT_CACHE_DIR", cache.path())
+            .args(["occurrences", "target_ident", "--compact"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("compact output is utf8");
+
+        assert_eq!(
+            stdout,
+            "src/lib.rs:1 pub fn target_ident() {}\n\
+             src/lib.rs:2 pub fn call() { target_ident(); }\n",
+            "compact output must stay a terse path:line plus one context line snapshot"
+        );
     }
 
     #[test]
@@ -6234,6 +6402,95 @@ mod occurrences_cli {
             human_find_str.contains("scanned 3 of 3 repo files; artifact-flagged: generated(1)")
         );
     }
+
+    #[test]
+    fn occurrences_scans_extensionless_text_files_and_excludes_binary() {
+        let temp = TempDir::new().expect("temp project");
+        let cache = TempDir::new().expect("cache dir");
+        let root = temp.path();
+
+        std::fs::create_dir_all(root.join("bin")).expect("create bin dir");
+        std::fs::write(
+            root.join("LICENSE"),
+            "LOCTREE_EXTENSIONLESS_LICENSE_TOKEN grants literal truth.\n",
+        )
+        .expect("write LICENSE");
+        std::fs::write(
+            root.join("bin/bootstrap"),
+            "#!/usr/bin/env bash\necho LOCTREE_EXTENSIONLESS_SCRIPT_TOKEN\n",
+        )
+        .expect("write bootstrap");
+        std::fs::write(
+            root.join("extensionless-binary"),
+            b"LOCTREE_EXTENSIONLESS_BINARY_TOKEN\0still binary",
+        )
+        .expect("write binary fixture");
+
+        run_git(root, &["init"]);
+        run_git(root, &["add", "."]);
+
+        let license_output = loctree()
+            .current_dir(root)
+            .env("LOCT_CACHE_DIR", cache.path())
+            .args([
+                "occurrences",
+                "LOCTREE_EXTENSIONLESS_LICENSE_TOKEN",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let license_json: Value =
+            serde_json::from_slice(&license_output).expect("license occurrences json");
+        assert_eq!(license_json["total"], 1);
+        let license_hits = license_json["occurrences"]
+            .as_array()
+            .expect("license occurrence list");
+        assert_eq!(license_hits[0]["file"], "LICENSE");
+
+        let script_output = loctree()
+            .current_dir(root)
+            .env("LOCT_CACHE_DIR", cache.path())
+            .args([
+                "occurrences",
+                "LOCTREE_EXTENSIONLESS_SCRIPT_TOKEN",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let script_json: Value =
+            serde_json::from_slice(&script_output).expect("script occurrences json");
+        assert_eq!(script_json["total"], 1);
+        let script_hits = script_json["occurrences"]
+            .as_array()
+            .expect("script occurrence list");
+        assert_eq!(script_hits[0]["file"], "bin/bootstrap");
+
+        let binary_output = loctree()
+            .current_dir(root)
+            .env("LOCT_CACHE_DIR", cache.path())
+            .args([
+                "occurrences",
+                "LOCTREE_EXTENSIONLESS_BINARY_TOKEN",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let binary_json: Value =
+            serde_json::from_slice(&binary_output).expect("binary occurrences json");
+        assert_eq!(
+            binary_json["total"], 0,
+            "NUL-bearing extensionless binary must not enter literal scan universe"
+        );
+    }
 }
 
 // ============================================
@@ -6247,7 +6504,7 @@ mod find_literal_cli {
     /// `loct find --literal <ident> --json` must return a `literal_matches`
     /// section whose occurrences are byte-for-byte the same lines `loct
     /// occurrences` surfaces — every result tagged `source: "literal"`, and the
-    /// buried-local codescribe lines (`let mut utterance_id`, `utterance_id += 1`)
+    /// buried-local CodeScribe lines (`let mut utterance_id`, `utterance_id += 1`)
     /// present. This is the W1-B acceptance: when the mode says literal, the
     /// answer is literal.
     #[test]
@@ -6652,7 +6909,7 @@ mod occurrences_quality_cli {
     }
 
     /// `--whole-token` tightens the boundary so `backdrop` stops matching inside
-    /// hyphenated neighbors (`--sample-z-overlay-backdrop`, `backdrop-filter`),
+    /// hyphenated neighbors (`--vista-z-overlay-backdrop`, `backdrop-filter`),
     /// cutting the z-index noise — while the default boundary is unchanged.
     #[test]
     fn whole_token_cuts_hyphenated_noise() {
@@ -6670,7 +6927,7 @@ mod occurrences_quality_cli {
         assert!(
             tight_occ.iter().all(|o| {
                 let ctx = o["context"].as_str().unwrap_or("");
-                !ctx.contains("--sample-z-overlay-backdrop")
+                !ctx.contains("--vista-z-overlay-backdrop")
             }) || tight_occ.iter().all(|o| o["matched_text"] == "backdrop"),
             "whole_token must not surface a hit *inside* the hyphenated custom property"
         );
@@ -6679,9 +6936,9 @@ mod occurrences_quality_cli {
             !tight_occ.iter().any(|o| o["context"]
                 .as_str()
                 .unwrap_or("")
-                .contains("--sample-z-overlay-backdrop")
+                .contains("--vista-z-overlay-backdrop")
                 && o["occurrence_kind"] == "custom_property"),
-            "the `--sample-z-overlay-backdrop` noise hit must be gone under whole_token"
+            "the `--vista-z-overlay-backdrop` noise hit must be gone under whole_token"
         );
     }
 
@@ -6752,7 +7009,7 @@ mod occurrences_quality_cli {
         fs::create_dir_all(&subdir).unwrap();
         fs::write(
             subdir.join("styles.css"),
-            "/* backdrop */\n.backdrop { --sample-z-overlay-backdrop: 40; }\n",
+            "/* backdrop */\n.backdrop { --vista-z-overlay-backdrop: 40; }\n",
         )
         .unwrap();
         fs::write(
@@ -7408,7 +7665,7 @@ mod dead_truth {
         );
     }
 
-    /// Empiria: example-app lazy-import `import('./Steps').then((m) => m.InviteTeamStep)`
+    /// Empiria: Vista lazy-import `import('./Steps').then((m) => m.InviteTeamStep)`
     /// — the named export consumed only through the dynamic-import member
     /// access must not be dead.
     #[test]
@@ -7424,7 +7681,7 @@ mod dead_truth {
         );
     }
 
-    /// Empiria: codescribe stt-bridge — runtime entry files spawned only by
+    /// Empiria: CodeScribe stt-bridge — runtime entry files spawned only by
     /// string. The fixture carries BOTH a Cargo [[bin]]
     /// (`src/bin/stt_bridge.rs`) and a package.json bin
     /// (`daemon/voice_daemon.js`, spawned via `spawn('voice-daemon')`).

--- a/loctree-rs/tests/fixtures/dead_truth_lazy/src/App.tsx
+++ b/loctree-rs/tests/fixtures/dead_truth_lazy/src/App.tsx
@@ -1,4 +1,4 @@
-// example-app pattern: React.lazy() extracting a NAMED export from a dynamic import.
+// Vista pattern: React.lazy() extracting a NAMED export from a dynamic import.
 const InviteTeam = () =>
   import('./Steps').then((m) => ({ default: m.InviteTeamStep }));
 

--- a/loctree-rs/tests/fixtures/dead_truth_spawn/src/lib.rs
+++ b/loctree-rs/tests/fixtures/dead_truth_spawn/src/lib.rs
@@ -1,5 +1,5 @@
 //! Spawner side: references the bridge binary only by its string name —
-//! the codescribe stt-bridge empiria (file "dead" in the graph, alive at
+//! the CodeScribe stt-bridge empiria (file "dead" in the graph, alive at
 //! runtime via Command::new("stt-bridge")).
 
 pub fn spawn_bridge() -> std::io::Result<std::process::Child> {

--- a/loctree-rs/tests/fixtures/env_drift/.env
+++ b/loctree-rs/tests/fixtures/env_drift/.env
@@ -1,5 +1,5 @@
 # Fresh local credentials — operator has just rotated DATABASE_URL.
 # Compare against k8s/sealed-secret.yaml: same key, stale ciphertext.
-DATABASE_URL=postgres://fresh-credentials@localhost:5432/example_app
+DATABASE_URL=postgres://fresh-credentials@localhost:5432/vista
 API_KEY=fresh-rotated-key-2026
 LOG_LEVEL=info

--- a/loctree-rs/tests/fixtures/env_drift/README.md
+++ b/loctree-rs/tests/fixtures/env_drift/README.md
@@ -1,6 +1,6 @@
 # env_drift fixture (Cut 8 / Lane 4)
 
-Synthesises the example-app April-2026 incident pattern.
+Synthesises the Vista April-2026 incident pattern.
 
 - `.env` — fresh local credentials (operator just rotated `DATABASE_URL`).
 - `k8s/sealed-secret.yaml` — production SealedSecret with **stale** ciphertext

--- a/loctree-rs/tests/fixtures/env_drift/docker-compose.yml
+++ b/loctree-rs/tests/fixtures/env_drift/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   api:
-    image: example-app/api
+    image: vista/api
     environment:
-      DATABASE_URL: postgres://compose-host:5432/example-app
+      DATABASE_URL: postgres://compose-host:5432/vista
       LOG_LEVEL: debug
     env_file:
       - ./.env

--- a/loctree-rs/tests/fixtures/env_drift/k8s/configmap.yaml
+++ b/loctree-rs/tests/fixtures/env_drift/k8s/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-app-config
+  name: vista-config
   namespace: production
 data:
-  DATABASE_URL: postgres://other-host@db.svc:5432/example-app
+  DATABASE_URL: postgres://other-host@db.svc:5432/vista
   LOG_LEVEL: info
   FEATURE_FLAGS: '{"x":true}'

--- a/loctree-rs/tests/fixtures/env_drift/k8s/deployment.yaml
+++ b/loctree-rs/tests/fixtures/env_drift/k8s/deployment.yaml
@@ -1,29 +1,29 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-app-api
+  name: vista-api
   namespace: production
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: example-app-api
+      app: vista-api
   template:
     metadata:
       labels:
-        app: example-app-api
+        app: vista-api
     spec:
       containers:
         - name: api
-          image: ghcr.io/example-app/api:latest
+          image: ghcr.io/vista/api:latest
           env:
             - name: NODE_ENV
               value: production
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: example-app-credentials
+                  name: vista-credentials
                   key: DATABASE_URL
           envFrom:
             - configMapRef:
-                name: example-app-config
+                name: vista-config

--- a/loctree-rs/tests/fixtures/env_drift/k8s/sealed-secret.yaml
+++ b/loctree-rs/tests/fixtures/env_drift/k8s/sealed-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: example-app-credentials
+  name: vista-credentials
   namespace: production
 spec:
   encryptedData:
@@ -9,5 +9,5 @@ spec:
     API_KEY: AgC9pPmRQOyU9k0zKr4n0dXyL6qGw7tMnOvWyYABnZlCeStDgIxHrV0L8pOcWyZfJqKbDeGhRsUzNoWcDeFhRsUzNoWcDeFhRsUzNoWcDeFh==
   template:
     metadata:
-      name: example-app-credentials
+      name: vista-credentials
     type: Opaque

--- a/loctree-rs/tests/fixtures/occurrences_backdrop/styles.css
+++ b/loctree-rs/tests/fixtures/occurrences_backdrop/styles.css
@@ -1,5 +1,5 @@
 /* backdrop styling tokens */
 .backdrop {
   backdrop-filter: blur(2px);
-  --sample-z-overlay-backdrop: 40;
+  --vista-z-overlay-backdrop: 40;
 }

--- a/loctree-rs/tests/fixtures/occurrences_local_idents/src/lib.rs
+++ b/loctree-rs/tests/fixtures/occurrences_local_idents/src/lib.rs
@@ -1,4 +1,4 @@
-//! Fixture reproducing the codescribe `utterance_id` failure class.
+//! Fixture reproducing the CodeScribe `utterance_id` failure class.
 //!
 //! `utterance_id` is a *local* variable initialized and incremented deep
 //! inside a large function body — plus emitted as a struct field. AST/tagmap

--- a/loctree-rs/tests/no_self_shellout.rs
+++ b/loctree-rs/tests/no_self_shellout.rs
@@ -65,10 +65,10 @@ fn visit_rust_files(dir: &Path, sink: &mut dyn FnMut(&Path, &str)) {
         let path = entry.path();
         if path.is_dir() {
             visit_rust_files(&path, sink);
-        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
-            if let Ok(content) = fs::read_to_string(&path) {
-                sink(&path, &content);
-            }
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            sink(&path, &content);
         }
     }
 }


### PR DESCRIPTION
Snapshot sync of the 0.13.1 release from the private suite (component-sync staging; engine crates pinned from crates.io at 0.13.1 — loctree, loctree-ast, report-leptos, aicx 0.10.0). Carries the glama.json claim manifest where the manifest defines it.

Release content (from suite CHANGELOG 0.13.1): jetbrains `loctree/body` client wiring, private-repo reference purge in shipped surfaces, npm no-postinstall wrapper, report sidebar version from `CARGO_PKG_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)